### PR TITLE
Make almost all the files run in both Python 2 and Python 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Project homepage: https://github.com/kbat/mc-tools
    * [ace2root](https://github.com/kbat/mc-tools/blob/master/mctools/common/ace2root.py), a converter from ACE to ROOT formats. Loops through all available cross-sections in an ACE file and saves them as TGraph objects. We use this simple script to visualise [ENDF](http://www.nndc.bnl.gov/exfor/endf00.jsp) cross sections. Requires the [PyNE](http://pyne.io) toolkit to be installed.
 
 ## Requirements ##
-* Python 2. Versions >= 3 are not supported (with exception of the ```rotate3dshow.py``` script).
 * If you are going to use the ROOT-related scripts (such as mctal2root,
    ssw2root or angel2root), you need to have [ROOT](http://root.cern.ch)
    to be compiled with Python 2 support. Follow

--- a/mctools/common/CombLayer/adist.py
+++ b/mctools/common/CombLayer/adist.py
@@ -1,9 +1,16 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 from sys import argv, exit
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 import os, argparse, re, math
+
+# runs in both Python 2 and 3
+try:
+        input = raw_input
+except NameError:
+        pass
 
 def getFOM(mctal, tname, bins):
     """
@@ -40,10 +47,10 @@ def getTheta(tname, inp):
                 theta = 2*math.pi + math.atan2(x,y)
             theta *= 180/math.pi
             if found == True:
-                print "Error: theta has already been found in ", inp
+                print("Error: theta has already been found in ", inp)
             Found = True
             
-#            print inp, tname, x,y, theta
+#            print(inp, tname, x,y, theta)
     f.close()
     return theta
     
@@ -75,7 +82,7 @@ def main():
         tallies = args.tally.split(',')
 
     bins = args.bin.split(',')
-#    print "Tallies:", tallies
+#    print("Tallies:", tallies)
 
     nt = len(tallies)
     ge = ROOT.TGraphErrors(nt)
@@ -94,7 +101,7 @@ def main():
     ge.Fit("pol0", "q")
     average = ge.GetFunction("pol0").GetParameter(0)
     err = ge.GetFunction("pol0").GetParError(0)
-    print "(", average/1E+13, " +- ", err/1E+13, ") x 1E+13"
+    print("(", average/1E+13, " +- ", err/1E+13, ") x 1E+13")
 
     if args.draw:
         ge.Draw("ap")

--- a/mctools/common/CombLayer/getcell.py
+++ b/mctools/common/CombLayer/getcell.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import argparse, re
 from sys import exit
 from os import path
@@ -17,9 +18,9 @@ def getCombLayerCell(mcnpcell):
     for line in f.readlines():
         if re.search("^Cell Changed", line):
             words = line.strip().split()
-#            print words
+#            print(words)
             if int(words[3]) == int(mcnpcell):
-                print words
+                print(words)
                 clcell = int(words[2][1:])
     f.close()
     return clcell
@@ -35,7 +36,7 @@ def getCombLayerObject(clcell):
     for line in f.readlines():
         words = line.strip().split()
         if (int(words[1]) == c):
-            print words
+            print(words)
             obj = words[0]
     f.close()
     return obj
@@ -53,7 +54,7 @@ def main():
 
     clcell = getCombLayerCell(mcnpcell)
     obj = getCombLayerObject(clcell)
-    print obj
+    print(obj)
                 
 
 if __name__ == "__main__":

--- a/mctools/common/CombLayer/getfom-analysis.py
+++ b/mctools/common/CombLayer/getfom-analysis.py
@@ -1,6 +1,7 @@
 # An example of getfom-analysis.py used by getfom.py
 # Calculates change (first derivative) of TGraphErrors fitted with pol2
 #
+from __future__ import print_function
 gr.Sort()
 
 N = gr.GetN()
@@ -9,7 +10,7 @@ xmin = gr.GetX()[0]
 xmax = gr.GetX()[N-1]
 dx = xmax-xmin
 dy = gr.GetY()[N-1]-gr.GetY()[0]
-print dy/dx
+print(dy/dx)
 
 fit = gr.GetFunction("pol2")
 change = fit.GetParameter(1) + 2*fit.GetParameter(2)*gr.GetX()[0]

--- a/mctools/common/CombLayer/getfom.py
+++ b/mctools/common/CombLayer/getfom.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import print_function
 from sys import argv, exit
 from math import sqrt
 import ROOT
@@ -8,6 +9,12 @@ from comblayer import getPar as getParCL
 import glob, os, argparse
 from array import array
 from datetime import datetime
+
+# runs in both Python 2 and 3
+try:
+        input = raw_input
+except NameError:
+        pass
 
 def saveGraph(gr, fout):
     """
@@ -19,11 +26,11 @@ def saveGraph(gr, fout):
 
 def printGraph(gr):
     """ Prints TGraphErrors """
-    print "# ", gr.GetTitle()
-    print "# format: x ex y ey"
+    print("# ", gr.GetTitle())
+    print("# format: x ex y ey")
     N = gr.GetN()
     for i in range(N):
-        print i, gr.GetX()[i], gr.GetEX()[i], gr.GetY()[i], gr.GetEY()[i]
+        print(i, gr.GetX()[i], gr.GetEX()[i], gr.GetY()[i], gr.GetEY()[i])
 
 def getGraph(args, tname, color):
     x = []
@@ -32,12 +39,12 @@ def getGraph(args, tname, color):
     ey = []
     for mctal in glob.glob(args.mctal):
         dirname = os.path.split(mctal)[0]
-#        print dirname
+#        print(dirname)
         inp = os.path.join(dirname, 'inp')
         f = ROOT.TFile(mctal)
         if args.axis>=0: # axis and bin are specified
             f.Get(tname).GetAxis(2).SetRange(1,1)
-            print >> sys.stderr, "f.Get(tname).GetAxis(2).SetRange(1,1) called!"
+            print("f.Get(tname).GetAxis(2).SetRange(1,1) called!", file=sys.stderr)
             tally = f.Get(tname).Projection(args.axis);
         else: # args.bin is absolute bin number
             tally = f.Get(tname)
@@ -45,7 +52,7 @@ def getGraph(args, tname, color):
         ex.append(0.0)
 
         bins = args.bin.split(',')
-#        print "args.bin: ", bins
+#        print("args.bin: ", bins)
         nbins = len(bins)
         ytmp = 0.0
         eytmp = 0.0
@@ -57,11 +64,11 @@ def getGraph(args, tname, color):
         y.append(eval("%g%s" % (ytmp, args.yscale)))
         ey.append(eval("%g%s" % (eytmp, args.yscale)))
         f.Close()
-#    print x
-#    print y
+#    print(x)
+#    print(y)
 
 # sort all arrays
-    x,y,ex,ey = zip(*sorted(zip(x,y,ex,ey)))
+    x,y,ex,ey = list(zip(*sorted(zip(x,y,ex,ey))))
     gr = ROOT.TGraphErrors(len(x), array('f', x), array('f', y), array('f', ex), array('f', ey))
     gr.SetNameTitle("gr%s" % tname, args.title)
     gr.GetXaxis().SetTitle(args.xtitle)
@@ -97,7 +104,7 @@ def getAverage(args, mg):
                 y[i] = y[i] + gr.GetY()[i]/ngr
                 ey[i] = ey[i] + pow(gr.GetEY()[i], 2)/ngr
         first = False
-        ey = map(sqrt, ey)
+        ey = list(map(sqrt, ey))
 
     gr = ROOT.TGraphErrors(len(x), array('f', x), array('f', y), array('f', ex), array('f', ey))
     gr.SetNameTitle("grAverage", "%s;%s;%s" % (title, args.xtitle, args.ytitle))
@@ -220,7 +227,9 @@ def main():
     if os.path.isfile(analysis_fname):
         fan = open(analysis_fname)
         for l in fan.readlines():
-            exec l
+            # "The Python 3 syntax without the global and local dictionaries
+            # will work in Python 2 as well:" (from `Supporting Python 3' by L. Regebro et al.)
+            exec(l)
 
 
     if args.pdf == "do not save":

--- a/mctools/common/CombLayer/getomega.py
+++ b/mctools/common/CombLayer/getomega.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 from comblayer import getOmega, getPar
 import argparse, sys
 
@@ -15,9 +16,9 @@ def main():
     if args.inv:
         omega = 1.0/omega
     if args.verbose:
-        print args.inp, args.col, omega, "sr"
+        print(args.inp, args.col, omega, "sr")
     else:
-        print omega
+        print(omega)
 
 if __name__=="__main__":
     sys.exit(main())

--- a/mctools/common/CombLayer/getsurf.py
+++ b/mctools/common/CombLayer/getsurf.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import argparse, re
 from sys import exit
 from os import path
@@ -18,7 +19,7 @@ def getCombLayerSurf(mcnpsurf):
         if re.search("^Surf Change", line):
             words = line.strip().split()
             if int(words[-1]) == int(mcnpsurf):
-                print words
+                print(words)
                 clsurf = int(words[1].split(":")[1])
     f.close()
     return clsurf
@@ -36,7 +37,7 @@ def main():
 
     clsurf = getCombLayerSurf(mcnpsurf)
 #    obj = getCombLayerObject(clsurf)
-    print clsurf
+    print(clsurf)
                 
 
 if __name__ == "__main__":

--- a/mctools/common/CombLayer/paster/cl-add-variable.py
+++ b/mctools/common/CombLayer/paster/cl-add-variable.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python -W all
 #
 
+from __future__ import print_function
 import argparse, os, re, sys
 import fileinput
 from mctools import checkPaths
@@ -12,7 +13,7 @@ def checkName(n, t):
     """
     if len(n) == 0:
         if not re.search("vector",t) and not re.search("shared_ptr", t):
-            print>>sys.stderr, "Argument '-name' must be specified for type '%s'" % t
+            print("Argument '-name' must be specified for type '%s'" % t, file=sys.stderr)
             sys.exit(4)
 
 def main():
@@ -46,8 +47,8 @@ def main():
     if checkPaths([hDir, cxxDir], [h,cxx]) > 0:
         sys.exit(1)
 
-    print h
-    print cxx
+    print(h)
+    print(cxx)
     mat = False
     hFixed = False
     ccFixed = False
@@ -61,10 +62,10 @@ def main():
 
 # fix the header
     for line in fileinput.input(h, inplace=True, backup='.bak'):
-       print line.rstrip()
+       print(line.rstrip())
        if re.search(" %s;" % args.after, line):
            hFixed = True
-           print "  %s %s; ///< %s" % (args.type, args.var, args.comment)
+           print("  %s %s; ///< %s" % (args.type, args.var, args.comment))
 
 # fix implementation
     for line in fileinput.input(cxx, inplace=True, backup='.bak'):
@@ -107,18 +108,18 @@ def main():
             else:
                 l = "  %s=Control.EvalVar<%s>(keyName+\"%s\");" % (args.var, args.type, args.name)
 
-        print line
+        print(line)
         if l:
-            print l
+            print(l)
 
     if not hFixed:
-        print>>sys.stderr, "!!! No record added in the header"
+        print("!!! No record added in the header", file=sys.stderr)
     if not ccFixed:
-        print>>sys.stderr, "!!! No record added in the copy constructor"
+        print("!!! No record added in the copy constructor", file=sys.stderr)
     if not equalFixed:
-        print>>sys.stderr, "!!! No record added in the operator="
+        print("!!! No record added in the operator=", file=sys.stderr)
     if not evalFixed:
-        print>>sys.stderr, "!!! No record added in the %s::populate() method." % args.className
+        print("!!! No record added in the %s::populate() method." % args.className, file=sys.stderr)
                 
 if __name__ == "__main__":
     sys.exit(main())

--- a/mctools/common/CombLayer/paster/cl-paster.py
+++ b/mctools/common/CombLayer/paster/cl-paster.py
@@ -2,6 +2,7 @@
 #
 # Paster for CombLayer
 
+from __future__ import print_function
 from sys import exit,stderr
 import argparse, re
 import os
@@ -45,9 +46,9 @@ class Paster:
         """
 
         if os.path.isfile(dest):
-            print "File %s exists -> aborting" % dest
+            print("File %s exists -> aborting" % dest)
             exit(1)
-        print dest
+        print(dest)
     
         fin = open(source)
         fout = open(dest, 'w')

--- a/mctools/common/ace2root.py
+++ b/mctools/common/ace2root.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python
 
 #%matplotlib inline
+from __future__ import print_function
 from pylab import savefig
 import matplotlib.pyplot as plt
 from pyne import ace
@@ -17,7 +18,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.isfile(args.acefile):
-        print >> sys.stderr, "ace2root: File %s does not exist." % args.acefile
+        print("ace2root: File %s does not exist." % args.acefile, file=sys.stderr)
         sys.exit(1)
 
     if args.rootfile == "":
@@ -31,21 +32,21 @@ def main():
     ntables = len(lib.tables)
 
     if not ntables:
-        print >> sys.stderr, "ace2root: no tables found in", args.acefile
+        print("ace2root: no tables found in", args.acefile, file=sys.stderr)
         sys.exit(2)
 #    else:
-#        print ntables, "tables found"
+#        print(ntables, "tables found")
 
     rootfile = ROOT.TFile(rootFileName, "recreate")
 
     for tname in lib.tables:
         table = lib.tables[tname]
-#        print tname, table.reactions
+#        print(tname, table.reactions)
         newdir = ROOT.gDirectory.mkdir(tname, "");
         newdir.cd()
         for mt in table.reactions:
             reaction = table.find_reaction(mt)
-#            print reaction.text
+#            print(reaction.text)
             gr = ROOT.TGraph(len(table.energy), table.energy, reaction.sigma)
             gr.SetName("mt%s" % str(mt))
             gr.SetTitle("%s #bullet MT=%d;Enegy [MeV];#sigma [barn]" % (tname, mt))

--- a/mctools/common/ascii2gr.py
+++ b/mctools/common/ascii2gr.py
@@ -2,9 +2,9 @@
 #
 # ASCII to TGraph  converter
 
+from __future__ import print_function
 import sys,time,os,re
 from array import array
-from string import join
 import argparse
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -41,7 +41,7 @@ def GetAsymmGraph(colx, exlow, exhigh, coly, eylow, eyhigh, fname, l1, l2, name,
         l2 = len(ftmp.readlines()) # set to the number of lines in the file
         ftmp.close()
 
-    print "--->reading between lines", l1, l2
+    print("--->reading between lines", l1, l2)
 
     f = open(fname)
     for nline, line in enumerate(f.readlines(), 1):
@@ -49,18 +49,18 @@ def GetAsymmGraph(colx, exlow, exhigh, coly, eylow, eyhigh, fname, l1, l2, name,
         if l2 and nline>l2: break
 
         words = line.split()
-#        print words, len(words)
+#        print(words, len(words))
 
         if len(words) == 0:
             if npoints == 0:
                 continue # we have not read any points yet -> just continue
             else:
-#            print "creating new graph object"
+#            print("creating new graph object")
                 break
         if words[0][0] == '#':
             continue
         if len(words) < 2:
-            print "Skipping line ", line.strip()
+            print("Skipping line ", line.strip())
             continue
 
         vx.append(float(words[colx-1]))
@@ -76,7 +76,7 @@ def GetAsymmGraph(colx, exlow, exhigh, coly, eylow, eyhigh, fname, l1, l2, name,
 
     f.close()
 
-#    print "number of points: ", npoints
+#    print("number of points: ", npoints)
 
     if npoints>0:
 
@@ -95,7 +95,7 @@ def GetAsymmGraph(colx, exlow, exhigh, coly, eylow, eyhigh, fname, l1, l2, name,
                     
         graphs.Add(gr)
 
-#    print "nlines:", nline, l2
+#    print("nlines:", nline, l2)
     if nline<l2:
         GetAsymmGraph(colx, exlow, exhigh, coly, eylow, eyhigh, fname, nline+1, l2, name, graphs, name_index)
 
@@ -119,7 +119,7 @@ def GetGraph(colx, colex, coly, coley, fname, l1, l2, name, title, graphs, name_
         l2 = len(ftmp.readlines()) # set to the number of lines in the file
         ftmp.close()
 
-    print "--->reading between lines", l1, l2
+    print("--->reading between lines", l1, l2)
 
     f = open(fname)
     for nline, line in enumerate(f.readlines(), 1):
@@ -127,26 +127,26 @@ def GetGraph(colx, colex, coly, coley, fname, l1, l2, name, title, graphs, name_
         if l2 and nline>l2: break
 
         words = line.split()
-#        print words, len(words)
+#        print(words, len(words))
 
         if len(words) == 0:
             if npoints == 0:
                 continue # we have not read any points yet -> just continue
             else:
-#            print "creating new graph object"
+#            print("creating new graph object")
                 break
 
         if words[0][0] == '#':
             # set titles in the case of data files downloaded from nndc.bnl.gov/exfor
             if words[0] == '#name:':
-                title = join(words[1:])
+                title = ' '.join(words[1:])
             elif words[0] == '#X.axis:':
-                xtitle = join(words[1:])
+                xtitle = ' '.join(words[1:])
             elif words[0] == '#Y.axis:':
-                ytitle = join(words[1:])
+                ytitle = ' '.join(words[1:])
             continue
         if len(words) < 2:
-            print "Skipping line ", line.strip()
+            print("Skipping line ", line.strip())
             continue
 
         vx.append(float(words[colx-1]))
@@ -161,7 +161,7 @@ def GetGraph(colx, colex, coly, coley, fname, l1, l2, name, title, graphs, name_
 
     f.close()
 
-#    print "number of points: ", npoints
+#    print("number of points: ", npoints)
 
     if npoints>0:
 
@@ -199,9 +199,9 @@ def GetGraph(colx, colex, coly, coley, fname, l1, l2, name, title, graphs, name_
                     
         graphs.Add(gr)
 
-#    print "nlines:", nline, l2
+#    print("nlines:", nline, l2)
     if nline<l2:
-#        print "again"
+#        print("again")
         GetGraph(colx, colex, coly, coley, fname, nline+1, l2, name, graphs, name_index)
 
 def main():
@@ -231,7 +231,7 @@ def main():
     parser.add_argument('-eylow', dest='eylow', type=int, help='low abs error on Y in the case of TGraphAsymmErrors')
     parser.add_argument('-eyhigh', dest='eyhigh', type=int, help='high abs error on Y in the case of TGraphAsymmErrors')
 
-    print parser.parse_args()
+    print(parser.parse_args())
 
     results = parser.parse_args()
 
@@ -242,7 +242,7 @@ def main():
         fname_out = fname_in.replace(".dat", ".root")
     
     if fname_in == fname_out: fname_out = fname_in + ".root"
-    print fname_in, '=>',fname_out
+    print(fname_in, '=>',fname_out)
 
     if results.update:
         fout_option = 'update'

--- a/mctools/common/ascii2th1.py
+++ b/mctools/common/ascii2th1.py
@@ -2,6 +2,7 @@
 #
 # ASCII to TH1F converter
 
+from __future__ import print_function
 import sys,time,os,re
 from array import array
 import ROOT, argparse
@@ -9,8 +10,8 @@ import ROOT, argparse
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 def GetHistogram(colxmin, colxmax, coly, coley, opt, hname, htitle, fname):
-#    print colxmin, colxmax, coly, coley, opt, fname
-    print opt
+#    print(colxmin, colxmax, coly, coley, opt, fname)
+    print(opt)
     f = open(fname)
     vx = []  # upper border of the energy bin
     vy = []  # flux
@@ -21,7 +22,7 @@ def GetHistogram(colxmin, colxmax, coly, coley, opt, hname, htitle, fname):
 
     for iline,line in enumerate(f.readlines()):
         words = line.split()
-#        print words;
+#        print(words);
         if len(words) == 0:
             break
         if words[0][0] == '#':
@@ -50,9 +51,9 @@ def GetHistogram(colxmin, colxmax, coly, coley, opt, hname, htitle, fname):
 
     f.close()
 
-#    print "vx", vx
-#    print "vy", vy
-#    print "ey", vey
+#    print("vx", vx)
+#    print("vy", vy)
+#    print("ey", vey)
 
     nbins = len(vy)
     h = ROOT.TH1F(hname, htitle, nbins, array('f', vx))
@@ -99,14 +100,14 @@ def main():
     results = parser.parse_args()
 
     if len(sys.argv) == 1:
-        print main.__doc__
+        print(main.__doc__)
         sys.exit(1)
 
 
     fname_in = results.inname
     fname_out = fname_in.replace(".dat", ".root")
     if fname_in == fname_out: fname_out = fname_in + ".root"
-    print fname_in, '=>',fname_out
+    print(fname_in, '=>',fname_out)
 
     fout = ROOT.TFile(fname_out, "recreate")
     GetHistogram(results.colxmin, results.colxmax, results.coly, results.coley, results.option, results.hname, results.htitle, fname_in).Write()

--- a/mctools/common/ascii2th3.py
+++ b/mctools/common/ascii2th3.py
@@ -2,6 +2,7 @@
 #
 # ASCII to TH3F converter
 
+from __future__ import print_function
 import sys,time,os,re
 from ROOT import ROOT, TH3F, TH1F, TFile
 from array import array
@@ -13,7 +14,7 @@ def str2float(s):
     f = []
     for i in s:
         f.append(float(i))
-    print "array: ", f
+    print("array: ", f)
     return f
         
 
@@ -62,25 +63,25 @@ def main():
 
     vx = sorted(str2float(list(set(x))))
 #    vx =  [ x*-1 for x in vx[::-1]] + vx[1:]
-#    print "\n!!! vx: added reversed values - used only for polar plots !!!\n"
+#    print("\n!!! vx: added reversed values - used only for polar plots !!!\n")
     vy = sorted(str2float(list(set(y))))
     vz = sorted(str2float(list(set(z))))
 #    vz =  [-600] + [ z*-1 for z in vz[::-1]] + vz[1:] + [600] # !!! add reversed values - used only for polar plots !!!
-#    print "\n!!! vz: added reversed values - used only for polar plots !!!\n"
+#    print("\n!!! vz: added reversed values - used only for polar plots !!!\n")
 
-#        print i, j, k
+#        print(i, j, k)
 #        val[(i,j,k)] = w[6]
 #        relerr[(i,j,k)] = w[7]
 
-    print "x: ", vx
-    print "y: ", vy
-    print "z: ", vz
+    print("x: ", vx)
+    print("y: ", vy)
+    print("z: ", vz)
 
     nx = len(vx)-1
     ny = len(vy)-1
     nz = len(vz)-1
     
-    print nx, ny, nz
+    print(nx, ny, nz)
 
     h = TH3F("neutron", "%s;%s;%s;%s" % (title, xtitle, ytitle, ztitle), nx, array('f', vx), ny, array('f', vy), nz, array('f', vz))
 

--- a/mctools/common/ascii2tree.py
+++ b/mctools/common/ascii2tree.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import print_function
 from ROOT import ROOT, TFile, TTree
 from sys import argv, exit
 
@@ -8,7 +9,7 @@ name_out = argv[2]
 branchDescriptor=""
 if len(argv)==4:
         branchDescriptor=argv[3]
-        print branchDescriptor
+        print(branchDescriptor)
 
 fout = TFile(name_out, "recreate")
 T = TTree("T", branchDescriptor)

--- a/mctools/common/h2ascii.py
+++ b/mctools/common/h2ascii.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import print_function
 from sys import argv, exit
 from ROOT import ROOT, TFile, TH1, TH2, TH3
 
@@ -11,37 +12,37 @@ def main():
 
     f = TFile(fname)
     h = f.Get(hname)
-    print "#", h.GetName(), h.GetTitle()
-    print "#", h.GetXaxis().GetTitle()
-    print "#", h.GetYaxis().GetTitle()
+    print("#", h.GetName(), h.GetTitle())
+    print("#", h.GetXaxis().GetTitle())
+    print("#", h.GetYaxis().GetTitle())
     if h.InheritsFrom("TH1") or h.InheritsFrom("TH2"):
-        print "#", h.GetZaxis().GetTitle()
-        print "# xmin xmax y y_rel_error"
+        print("#", h.GetZaxis().GetTitle())
+        print("# xmin xmax y y_rel_error")
     elif h.InheritsFrom("TGraph"):
-        print "# x x_abs_err y y_abs_err"
+        print("# x x_abs_err y y_abs_err")
 
     if h.InheritsFrom("TH2"):
         nbinsx, nbinsy = h.GetNbinsX(), h.GetNbinsY()
-#        print nbinsx, nbinsy
+#        print(nbinsx, nbinsy)
         for xbin in range(1, nbinsx+1):
             for ybin in range(1, nbinsy+1):
                 error = 0.0
                 val = h.GetBinContent(xbin, ybin)
                 if val != 0:  error = h.GetBinError(xbin, ybin) / val
-                print h.GetXaxis().GetBinLowEdge(xbin), h.GetXaxis().GetBinLowEdge(xbin+1), h.GetYaxis().GetBinLowEdge(ybin), h.GetYaxis().GetBinLowEdge(ybin+1), val, error
+                print(h.GetXaxis().GetBinLowEdge(xbin), h.GetXaxis().GetBinLowEdge(xbin+1), h.GetYaxis().GetBinLowEdge(ybin), h.GetYaxis().GetBinLowEdge(ybin+1), val, error)
             
     elif h.InheritsFrom("TH1"):
         nbins = h.GetNbinsX()
         error = 0.0
         for bin in range(1, nbins+1):
-            #        print h.GetBinLowEdge(bin), h.GetBinLowEdge(bin+1), h.GetBinContent(bin), h.GetBinError(bin)/h.GetBinContent(bin)
+            #        print(h.GetBinLowEdge(bin), h.GetBinLowEdge(bin+1), h.GetBinContent(bin), h.GetBinError(bin)/h.GetBinContent(bin))
             error = 0.0
             if h.GetBinContent(bin) != 0:  error = h.GetBinError(bin) / h.GetBinContent(bin)
-            print h.GetBinLowEdge(bin), h.GetBinLowEdge(bin+1), h.GetBinContent(bin), error
+            print(h.GetBinLowEdge(bin), h.GetBinLowEdge(bin+1), h.GetBinContent(bin), error)
     elif h.InheritsFrom("TGraph"):
         n = h.GetN()
         for i in range(n):
-            print i, h.GetX()[i], h.GetEX()[i], h.GetY()[i], h.GetEY()[i]
+            print(i, h.GetX()[i], h.GetEX()[i], h.GetY()[i], h.GetEY()[i])
 
 if __name__ == "__main__":
     exit(main())

--- a/mctools/common/hadd_av.py
+++ b/mctools/common/hadd_av.py
@@ -1,7 +1,8 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 from sys import argv, exit
-from string import join, ascii_lowercase, digits
+from string import ascii_lowercase, digits
 from os  import system
 from random import choice
 
@@ -12,15 +13,15 @@ def main():
 
     outfile = argv[1]
     tmpfname = '/tmp/hadd-av' + ''.join(choice(ascii_lowercase + digits) for x in range(8)) + '.root'
-    print tmpfname
+    print(tmpfname)
 
  #   open(tmpfile).close()
     files = argv[2:]
     nfiles = len(files)
 
-    if system("hadd %s %s" % (tmpfname, join(files))): exit(1)
+    if system("hadd %s %s" % (tmpfname, ' '.join(files))): exit(1)
 
-    print 'number of files:', nfiles
+    print('number of files:', nfiles)
 
 if __name__ == '__main__':
     exit(main())

--- a/mctools/common/lambdabins.py
+++ b/mctools/common/lambdabins.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import print_function
 import sys, argparse
 from string import strip
 from mctools import L2E, E2L
@@ -46,14 +47,14 @@ def main():
     args = parser.parse_args()
 
     if args.edgesE:
-        edgesE = map(float, map(strip, args.edgesE.split(',')))
+        edgesE = list(map(float, list(map(strip, args.edgesE.split(',')))))
     else:
         edgesE = []
 
     if args.width:
-        print textwrap.fill(" ".join(map(str, LambdaBins(args.nbins, args.lmin, args.lmax, edgesE))), width=80, subsequent_indent=" "*7)
+        print(textwrap.fill(" ".join(map(str, LambdaBins(args.nbins, args.lmin, args.lmax, edgesE))), width=80, subsequent_indent=" "*7))
     else:
-        print " ".join(map(str, LambdaBins(args.nbins, args.lmin, args.lmax, edgesE)))
+        print(" ".join(map(str, LambdaBins(args.nbins, args.lmin, args.lmax, edgesE))))
 
 if __name__=="__main__":
     sys.exit(main())

--- a/mctools/common/mixtures.py
+++ b/mctools/common/mixtures.py
@@ -2,6 +2,7 @@
 # Some examples of calculation of atomic fractions for the given volume fractions
 # https://github.com/kbat/mc-tools
 
+from __future__ import print_function
 from mctools import Isotope, Material, Compound
 
 H   = Isotope("01001.70c", 1.00794)
@@ -149,21 +150,21 @@ Copper.Print()
 
 ##### Compounds ####
 
-print "\n04005"
+print("\n04005")
 waterfrac = 0.05
 BeWater = Compound("BeH2O")
 BeWater.AddMaterial(water, waterfrac)
 BeWater.AddMaterial(beryllium, 1.0-waterfrac)
 #    BeWater.Print()
-print "Atomic fractions in %s with water vol fraction %g %%:" % (BeWater.name, waterfrac*100)
+print("Atomic fractions in %s with water vol fraction %g %%:" % (BeWater.name, waterfrac*100))
 BeWater.PrintAtomicFractions()
 
-print "\n04020"
+print("\n04020")
 waterfrac = 0.1
 BeD2O10 = Compound("BeD2O10%")
 BeD2O10.AddMaterial(D2O, waterfrac)
 BeD2O10.AddMaterial(beryllium, 1.0-waterfrac)
-print "Atomic fractions in %s with D2O vol fraction %g %%:" % (BeD2O10.name, waterfrac*100)
+print("Atomic fractions in %s with D2O vol fraction %g %%:" % (BeD2O10.name, waterfrac*100))
 BeD2O10.PrintAtomicFractions()
 
 
@@ -177,7 +178,7 @@ waterfrac = 0.1
 FeWater = Compound("IronH2O")
 FeWater.AddMaterial(water, waterfrac)
 FeWater.AddMaterial(Fe, 1.0-waterfrac)
-print "Atomic fractions in %s with water vol fraction %g %%:" % (FeWater.name, waterfrac*100)
+print("Atomic fractions in %s with water vol fraction %g %%:" % (FeWater.name, waterfrac*100))
 FeWater.PrintAtomicFractions()
 
 Zirconium = Material("Zirconium", 6.49)
@@ -191,7 +192,7 @@ waterfrac = 0.1
 ZrWater = Compound("ZrH2O")
 ZrWater.AddMaterial(water, waterfrac)
 ZrWater.AddMaterial(Zirconium, 1.0-waterfrac)
-print "Atomic fractions in %s with water vol fraction %g %%:" % (ZrWater.name, waterfrac*100)
+print("Atomic fractions in %s with water vol fraction %g %%:" % (ZrWater.name, waterfrac*100))
 ZrWater.PrintAtomicFractions()
 
 Lead = Material("Lead", 11.4)
@@ -200,36 +201,36 @@ Lead.AddIsotope(Pb206, 24.1)
 Lead.AddIsotope(Pb207, 22.1)
 Lead.AddIsotope(Pb208, 52.4)
 
-print "\n82010"
+print("\n82010")
 PbWater = Compound("PbH2O")
 PbWater.AddMaterial(water, waterfrac)
 PbWater.AddMaterial(Lead, 1.0-waterfrac)
-print "Atomic fractions in %s with water vol fraction %g %%:" % (PbWater.name, waterfrac*100)
+print("Atomic fractions in %s with water vol fraction %g %%:" % (PbWater.name, waterfrac*100))
 PbWater.PrintAtomicFractions()
 
-print "\n82020"
+print("\n82020")
 waterfrac = 0.1
 PbD2O = Compound("PbD2O20%")
 PbD2O.AddMaterial(D2O, waterfrac)
 PbD2O.AddMaterial(Lead, 1.0-waterfrac)
-print "Atomic fractions in %s with D2O vol fraction %g %%:" % (PbD2O.name, waterfrac*100)
+print("Atomic fractions in %s with D2O vol fraction %g %%:" % (PbD2O.name, waterfrac*100))
 PbD2O.PrintAtomicFractions()
 
-print "\nHelium"
+print("\nHelium")
 Helium = Material("Helium", 0.1786E-3)
 Helium.AddIsotope(He3, 0.00000137)
 Helium.AddIsotope(He4, 0.99999863)
 Helium.Print()
 
 waterfrac = float(0.2)
-print "\nSS316L and %.0f%% of water" % (waterfrac*100)
+print("\nSS316L and %.0f%% of water" % (waterfrac*100))
 SS316LH2O = Compound("SS316L20H2O")
 SS316LH2O.AddMaterial(water, waterfrac)
 SS316LH2O.AddMaterial(SS316L, 1-waterfrac)
 SS316LH2O.PrintAtomicFractions()
 
 
-print "\nWater and Al"
+print("\nWater and Al")
 
 waterfrac = 1-0.07 #
 waterAl = Compound("WaterAl")
@@ -238,24 +239,24 @@ waterAl.AddMaterial(Aluminium, 1-waterfrac)
 waterAl.PrintAtomicFractions()
 
 
-print "\nHydrogen and Al"
+print("\nHydrogen and Al")
 Alfrac = 2.9 # %
 ParaHAl = Compound("ParaHAl")
 ParaHAl.AddMaterial(Aluminium,Alfrac/100.0)
 ParaHAl.AddMaterial(Hydrogen,1-Alfrac/100.0)
 ParaHAl.PrintAtomicFractions()
 
-print "\nMagnesium"
+print("\nMagnesium")
 Mg.Print()
 
-print "\nClay Till Lera"
+print("\nClay Till Lera")
 ClayTillLera = Compound("ClayTillLera")
 ClayTillLera.AddMaterial(water,0.1)
 ClayTillLera.AddMaterial(Mg, 0.9)
 
 ClayTillLera.Print()
 
-print "\nPoly+Copper"
+print("\nPoly+Copper")
 Cable = Compound("Cable")
 Cable.AddMaterial(Poly,0.5)
 Cable.AddMaterial(Copper, 0.5)

--- a/mctools/common/plot1d.py
+++ b/mctools/common/plot1d.py
@@ -8,6 +8,12 @@ from sys import exit
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
+# runs in both Python 2 and 3
+try:
+        input = raw_input
+except NameError:
+        pass
+
 def main():
 	"""A simple TH1/TGraph plotter
 	"""

--- a/mctools/common/plot2d.py
+++ b/mctools/common/plot2d.py
@@ -3,10 +3,17 @@
 # https://github.com/kbat/mc-tools
 #
 
+from __future__ import print_function
 import argparse
 from sys import exit
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+# runs in both Python 2 and 3
+try:
+        input = raw_input
+except NameError:
+        pass
 
 def main():
 	"""A simple TH2 plotter with optional geometry overlay
@@ -68,7 +75,7 @@ def main():
             ROOT.gPad.SetLogz()
 
 
-        print "a", args.gfile
+        print("a", args.gfile)
         if args.gfile is not None:
             gf = ROOT.TFile(args.gfile)
             gh = gf.Get(args.ghist)

--- a/mctools/common/root2pgf.py
+++ b/mctools/common/root2pgf.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python -W all
 #
 
+from __future__ import print_function
 import sys, argparse
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -13,34 +14,34 @@ def h2pgf(h):
     """
     nbins = h.GetNbinsX()
 
-#    print "# \\begin{axis}"
-#    print "# \\addplot[const plot mark mid, black, solid, no markers, error bars/.cd, y dir=both, y explicit, error mark=none]"
-#    print " coordinates {"
-    print "x ex y ey"
+#    print("# \\begin{axis}")
+#    print("# \\addplot[const plot mark mid, black, solid, no markers, error bars/.cd, y dir=both, y explicit, error mark=none]")
+#    print(" coordinates {")
+    print("x ex y ey")
     for b in range(1, nbins+1):
         x = h.GetBinCenter(b)
         ex = h.GetBinWidth(b)/2.0
         y = h.GetBinContent(b)
         ey = h.GetBinError(b)
-# print x,ex,y,ey
+# print(x,ex,y,ey)
         if y>0.0:
-            print x, ex, y, ey
+            print(x, ex, y, ey)
 
 def g2pgf(h):
     """ Convert TGraph into pgfplot data """
 
     N = h.GetN()
 
-    print "\\begin{axis}"
-    print "\\addplot[ultra thick]"
-    print " coordinates {"
-    print "x ex y ey"
+    print("\\begin{axis}")
+    print("\\addplot[ultra thick]")
+    print(" coordinates {")
+    print("x ex y ey")
     for b in range(N):
         x = h.GetX()[b]
         y = h.GetY()[b]
-        print x, y
-    print "};"
-    print "\\addlegendentry{TGraph};"
+        print(x, y)
+    print("};")
+    print("\\addlegendentry{TGraph};")
 
 def main():
     """ A script to convert TH1 and TGraph into a pgfplot format """

--- a/mctools/common/scale_hist.py
+++ b/mctools/common/scale_hist.py
@@ -3,6 +3,7 @@
 # scales all histos in the given ROOT file by a given factor
 #
 
+from __future__ import print_function
 from sys import argv, exit
 from ROOT import TFile, TH1, TObject
 
@@ -20,9 +21,9 @@ def main():
     h0.SetDirectory(0)
     oldfile.Close()
 
-    print h0.GetBinContent(1)
+    print(h0.GetBinContent(1))
     h0.Scale(10)
-    print h0.GetBinContent(1)
+    print(h0.GetBinContent(1))
 
     newfile = TFile(newfname, "recreate")
     h0.Write()

--- a/mctools/common/vtk2root.py
+++ b/mctools/common/vtk2root.py
@@ -3,6 +3,7 @@
 # https://github.com/kbat/mc-tools
 #
 
+from __future__ import print_function
 import os,sys,re,numpy,argparse
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -13,7 +14,7 @@ class VTK:
         self.read()
 
     def Print(self):
-        print self.fname
+        print(self.fname)
 
     def read(self):
         "Read vtk file"
@@ -25,10 +26,10 @@ class VTK:
         
         if dataset != 'RECTILINEAR_GRID':
             sys.exit("Error: Unsupported format")
-        self.nx,self.ny,self.nz = map(int, f.readline().strip().split()[1:])
+        self.nx,self.ny,self.nz = list(map(int, f.readline().strip().split()[1:]))
         f.close()
 
-#        print title,form, dataset
+#        print(title,form, dataset)
         self.x = self.readCoordinates("X")
         self.y = self.readCoordinates("Y")
         self.z = self.readCoordinates("Z")
@@ -102,7 +103,7 @@ def main():
     if args.root == "":
         args.root = os.path.splitext(os.path.basename(args.vtk))[0] + ".root"
 
-    print "vtk2root: short integer values are assumed"
+    print("vtk2root: short integer values are assumed")
     fin = VTK(args.vtk)
     h = fin.getTH3()
     h.SaveAs(args.root)

--- a/mctools/fluka/eventdat2root.py
+++ b/mctools/fluka/eventdat2root.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import sys, argparse, os, struct
 from array import array
 from mctools.fluka.flair import fortran
@@ -22,7 +23,7 @@ def main():
 
     for f in args.eventdat:
         if not os.path.isfile(f):
-            print >> sys.stderr, "eventdat2root: File %s does not exist." % f
+            print("eventdat2root: File %s does not exist." % f, file=sys.stderr)
             return 1
 
     if not args.overwrite and os.path.isfile(args.root):
@@ -31,24 +32,24 @@ def main():
     first = True
     for eventdat in args.eventdat:
         with open(eventdat, 'rb') as f:
-            print eventdat
+            print(eventdat)
             while True:
                 data = fortran.read(f)
                 if data is None:
                     break
                 size = len(data)
-                print "\nsize:",size
+                print("\nsize:",size)
                 
                 if first:
                     first = False
 
                     title, time, nregs, nsco, dist = struct.unpack("=80s32siii", data)
 
-                    print "title:", title
-                    print "time:", time
-                    print "number of regions:",nregs
-                    print "number of scoring distributions:", nsco
-                    print "distribution:",dist
+                    print("title:", title)
+                    print("time:", time)
+                    print("number of regions:",nregs)
+                    print("number of scoring distributions:", nsco)
+                    print("distribution:",dist)
 
                     DATA = array('f', nsco*nregs*[0.0])
                     

--- a/mctools/fluka/fluka.py
+++ b/mctools/fluka/fluka.py
@@ -2,6 +2,7 @@
 # $Id$
 # $URL$
 
+from __future__ import print_function
 import sys, math, struct
 from mctools.mcnp.ssw import fortranRead
 
@@ -98,7 +99,7 @@ class USRBDXCARD:
             y = ie + ia*self.igmusx 
             val = self.gdstor[y]  # !!! FIX THIS !!!
             err = self.gbstor[y]
-#            print "ie,ia,y, val,err", ie, ia, y, val, err
+#            print("ie,ia,y, val,err", ie, ia, y, val, err)
             val /= self.engmax[y-1]-self.engmax[y]
         else:
             y = ie + ia*self.nebxbn 
@@ -117,105 +118,105 @@ class USRBDXCARD:
     def Print(self):
         def PrintV(val, sameline):
             """Prints value"""
-            print "%e" % val,
-            if not sameline: print "\n\t",
+            print("%e" % val, end='')
+            if not sameline: print("\n\t", end='')
         
         def PrintVE(val, err, sameline):
             """Prints value and error"""
-            print "%e +/- %g %%\t" % (val, err),
-            if not sameline: print "\n\t",
+            print("%e +/- %g %%\t" % (val, err), end='')
+            if not sameline: print("\n\t", end='')
 
-        print "\nDetector n: %d (%d) %s" % (self.nx, self.nx, self.titusx)
-        print "\t(Area: %g cmq," % self.ausbdx
-        print "\t distr. scored: %d," % self.idusbx
-        print "\t from reg. %d to %d," % (self.nr1usx, self.nr2usx)
+        print("\nDetector n: %d (%d) %s" % (self.nx, self.nx, self.titusx))
+        print("\t(Area: %g cmq," % self.ausbdx)
+        print("\t distr. scored: %d," % self.idusbx)
+        print("\t from reg. %d to %d," % (self.nr1usx, self.nr2usx))
 
-        if self.isOneWay(): print "\t one way scoring,"
-        else: print "\t this is a two ways estimator"
+        if self.isOneWay(): print("\t one way scoring,")
+        else: print("\t this is a two ways estimator")
         
-        if self.isFluence(): print "\t fluence scoring scoring)"
-        else: print "\t current scoring)"
+        if self.isFluence(): print("\t fluence scoring scoring)")
+        else: print("\t current scoring)")
         
-        print ""
+        print("")
         
-        print "\tTot. resp. (Part/cmq/pr) %e +/- %e %%" % (self.totresp, 100*self.totresperr)
-        print "\t( -->      (Part/pr)     %e +/- %e %% )"  % (self.totresp*self.ausbdx, 100*self.totresperr)
+        print("\tTot. resp. (Part/cmq/pr) %e +/- %e %%" % (self.totresp, 100*self.totresperr))
+        print("\t( -->      (Part/pr)     %e +/- %e %% )"  % (self.totresp*self.ausbdx, 100*self.totresperr))
 
-        print ""
+        print("")
 
-        print "\t**** Different. Fluxes as a function of energy ****",
-        print "\t****      (integrated over solid angle)        ****"
-        print "\t Energy boundaries (GeV):\n"
-        print "\t",
+        print("\t**** Different. Fluxes as a function of energy ****", end='')
+        print("\t****      (integrated over solid angle)        ****")
+        print("\t Energy boundaries (GeV):\n")
+        print("\t", end='')
         for i in range(self.nebxbn):
             PrintV(self.epgmax[i], (i+1) % 5)
-        print "\n\tLowest boundary (GeV):", self.epgmax[self.nebxbn] # if does not work, see UsxSuw::GetLowsetBoundary
+        print("\n\tLowest boundary (GeV):", self.epgmax[self.nebxbn]) # if does not work, see UsxSuw::GetLowsetBoundary
 
-        print "\n\tFlux (Part/GeV/cmq/pr):"
-        print "\t",
+        print("\n\tFlux (Part/GeV/cmq/pr):")
+        print("\t", end='')
         for i in range(self.nebxbn):
             PrintVE(self.flux[i], 100.0*self.fluxerr[i], (i+1)%2)
 
         if self.llnusx:
-            print "\t Energy boundaries (GeV):\n"
-            print "\t",
+            print("\t Energy boundaries (GeV):\n")
+            print("\t", end='')
             for i in range(self.igmusx): PrintV(self.engmax[i], (i+1) % 5)
-            print "\n\tLowest boundary (GeV):", self.engmax[i]
-            print self.igmusx
-#            print "here", len(self.gbstor), len(self.gdstor), self.nabxbn
-            print "\n\tFlux (Part/GeV/cmq/pr): (!!! SOMETHING IS WRONG WITH VALUE NORMALISATION HERE (not divided by energy?), BUT ERRORS ARE OK !!!)\n\t",
+            print("\n\tLowest boundary (GeV):", self.engmax[i])
+            print(self.igmusx)
+#            print("here", len(self.gbstor), len(self.gdstor), self.nabxbn)
+            print("\n\tFlux (Part/GeV/cmq/pr): (!!! SOMETHING IS WRONG WITH VALUE NORMALISATION HERE (not divided by energy?), BUT ERRORS ARE OK !!!)\n\t", end='')
             for ie in range(self.igmusx):
                 for ia in range(self.nabxbn):
                     val = self.getData(ie+1, ia, 'deg', True)
                     PrintVE(val[0], 100*val[1], (ie+1)%2)
                 
 
-        print "\n\t**** Cumulative Fluxes as a function of energy ****",
-        print "\t****      (integrated over solid angle)        ****"
+        print("\n\t**** Cumulative Fluxes as a function of energy ****", end='')
+        print("\t****      (integrated over solid angle)        ****")
 
-        print "\n\t Energy boundaries (GeV):"
-        print "\t",
+        print("\n\t Energy boundaries (GeV):")
+        print("\t", end='')
         for i in range(self.nebxbn):
             PrintV(self.epgmax[i], (i+1) % 5)
-        print "Lowest boundary (GeV):", self.epgmax[self.nebxbn] # if does not work, see
+        print("Lowest boundary (GeV):", self.epgmax[self.nebxbn]) # if does not work, see
 
-        print "\n\tCumul. Flux (Part/cmq/pr):\n\n\t",
+        print("\n\tCumul. Flux (Part/cmq/pr):\n\n\t", end='')
         for i in range(self.nebxbn):
             PrintVE(self.cumulflux[i], 100.0*self.cumulfluxerr[i], (i+1)%2)
 
         if self.llnusx:
-            print "\n\t Energy boundaries (GeV):\n"
-            print "\t",
+            print("\n\t Energy boundaries (GeV):\n")
+            print("\t", end='')
             for i in range(self.igmusx): PrintV(self.engmax[i], (i+1) % 5)
-            print "\n\tLowest boundary (GeV):", self.engmax[i]
+            print("\n\tLowest boundary (GeV):", self.engmax[i])
 
-            print "\n\tCumul. Flux (Part/cmq/pr):here\n\t",
+            print("\n\tCumul. Flux (Part/cmq/pr):here\n\t", end='')
 
             for i in range(self.igmusx):
                 PrintVE(self.cumulflux[i+self.nebxbn], 100*self.cumulfluxerr[i+self.nebxbn], (i+1)%2) # this is OK
         
         if self.nabxbn>1: # if more than one angle required
-            print "\n\t**** Double diff. Fluxes as a function of energy ****"
+            print("\n\t**** Double diff. Fluxes as a function of energy ****")
             alowedges = self.getALowEdge()
-            print "\tSolid angle minimum value (sr): ", alowedges[0]
-            print "\tSolid angle upper boundaries (sr):\n\t",
+            print("\tSolid angle minimum value (sr): ", alowedges[0])
+            print("\tSolid angle upper boundaries (sr):\n\t", end='')
             for i, val in enumerate(alowedges[1:], 1):
                 PrintV(val, i%5)
 
             alowedgesdeg = map(sr2deg, alowedges)
-            print "\n\tAngular minimum value (deg.): ", alowedgesdeg[0]
-            print "\tAngular upper boundaries (deg.):\n\t",
+            print("\n\tAngular minimum value (deg.): ", alowedgesdeg[0])
+            print("\tAngular upper boundaries (deg.):\n\t", end='')
             for i,val in enumerate(alowedgesdeg[1:], 1):
                 PrintV(val, i%5)
 
         # high-energy part
             for ie in range(self.nebxbn):
-                print "\n\tEnergy interval (GeV): %e %e" % (self.epgmax[ie], self.epgmax[ie+1])
-                print "\tFlux (Part/sr/GeV/cmq/pr):\n\t",
+                print("\n\tEnergy interval (GeV): %e %e" % (self.epgmax[ie], self.epgmax[ie+1]))
+                print("\tFlux (Part/sr/GeV/cmq/pr):\n\t", end='')
                 for ia in range(self.nabxbn):
                     val = self.getData(self.nebxbn-ie-1, ia, 'sr')
                     PrintVE(val[0], 100*val[1], (ia+1)%2)
-                print "Flux (Part/deg/GeV/cmq/pr):\n\t",
+                print("Flux (Part/deg/GeV/cmq/pr):\n\t", end='')
                 for ia in range(self.nabxbn):
                     val = self.getData(self.nebxbn-ie-1, ia, 'deg')
                     PrintVE(val[0], 100*val[1], (ia+1)%2)
@@ -226,19 +227,19 @@ class USRBDXCARD:
             
 
 
-        # print self.itusbx, self.idusbx, self.nr1usx, self.nr2usx, self.ausbdx, self.lwusbx, self.lfusbx, self.llnusx
-        # print "energy binning: ", self.ebxlow, self.ebxhgh, self.nebxbn, self.debxbn
-        # print "angular binning: ", self.abxlow, self.abxhgh, self.nabxbn, self.dabxbn
-        # print "number of low energy neutron groups: ", self.igmusx#, self.engmax
+        # print(self.itusbx, self.idusbx, self.nr1usx, self.nr2usx, self.ausbdx, self.lwusbx, self.lfusbx, self.llnusx)
+        # print("energy binning: ", self.ebxlow, self.ebxhgh, self.nebxbn, self.debxbn)
+        # print("angular binning: ", self.abxlow, self.abxhgh, self.nabxbn, self.dabxbn)
+        # print("number of low energy neutron groups: ", self.igmusx#, self.engmax)
 
-        # print "total responce: %e +- %g" % (self.totresp, self.totresperr)
+        # print("total responce: %e +- %g" % (self.totresp, self.totresperr))
 
 
 
 class USXSUW:
     def __init__(self, fname):
         self.fname = fname
-        print self.fname
+        print(self.fname)
 
         self.title  = ""
         self.time   = ""
@@ -297,26 +298,26 @@ class USXSUW:
             self.ubsarray.append(ubs)
 
         self.nrecords = record
-        print self.nrecords, "USRBDX cards found"
+        print(self.nrecords, "USRBDX cards found")
 
         for record in range(self.nrecords):
             data = fortranRead(self.file)
             ubs = self.ubsarray[record]
             ubs.totresp, ubs.totresperr = struct.unpack("=2f", data)
-#            print ubs.igmusx
+#            print(ubs.igmusx)
             data = fortranRead(self.file)
-#            print "here:", len(data)/4,  ubs.nebxbn+ubs.igmusx, ubs.getNbinsTotal()
+#            print("here:", len(data)/4,  ubs.nebxbn+ubs.igmusx, ubs.getNbinsTotal())
             vtmp = struct.unpack("=2i2f%df" % ubs.getNEbinsTotal(), data)
-            print "check:"
+            print("check:")
             if vtmp[0] != ubs.nebxbn: raise IOError("nebxbn record is wrong")
             if vtmp[1] != ubs.igmusx: raise IOError("igmusx record is wrong")
-            print "emin, emax:", vtmp[2], vtmp[3] # !!! maybe not only these 2 records are written when more than 1 user interval ???
+            print("emin, emax:", vtmp[2], vtmp[3]) # !!! maybe not only these 2 records are written when more than 1 user interval ???
             ubs.epgmax = vtmp[3:][:]
 
             data = fortranRead(self.file)
             ubs.flux = struct.unpack("=%df" % ubs.getNEbinsTotal(), data)
-#            print ubs.flux[1:10]
-#            print ubs.gdstor[1:10]
+#            print(ubs.flux[1:10])
+#            print(ubs.gdstor[1:10])
 
             data = fortranRead(self.file)
             ubs.fluxerr = struct.unpack("=%df" % ubs.getNEbinsTotal(), data)
@@ -333,16 +334,16 @@ class USXSUW:
                 
 
 
-        print ""
+        print("")
         #data = fortranRead(self.file)
-        #print len(data)
+        #print(len(data))
 
         self.file.close()
 
 
     def Print(self):
-        print self.title
-        print self.time
-        print self.wctot, self.nctot, self.mctot, self.mbatch
+        print(self.title)
+        print(self.time)
+        print(self.wctot, self.nctot, self.mctot, self.mbatch)
         for ubs in self.ubsarray:
             ubs.Print()

--- a/mctools/fluka/fluka2root.py
+++ b/mctools/fluka/fluka2root.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -Qwarn
-import sys, re, string, os, argparse
+from __future__ import print_function
+import sys, re, os, argparse
 import glob
 import tempfile
 
@@ -15,7 +16,7 @@ def printincolor(s,col=33):
     Print a string with a given color using ANSI/VT100 Terminal Control Escape Sequences
     http://www.termsys.demon.co.uk/vtansi.htm
     """
-    print "\033[1;%dm%s\033[0m" % (col, s)
+    print("\033[1;%dm%s\033[0m" % (col, s))
 
 
 class Estimator:
@@ -35,9 +36,9 @@ class Estimator:
         self.units[u].append(f)
 
     def Print(self):
-        print self.name
-        print " ", self.converter
-        print " units: ", self.units
+        print(self.name)
+        print(" ", self.converter)
+        print(" units: ", self.units)
 
 class Converter:
     def __init__(self, inp, overwrite, verbose):
@@ -67,8 +68,8 @@ class Converter:
         return 
 
         if self.verbose:
-            print "input files:", self.inp
-            print "output ROOT files:", self.root
+            print("input files:", self.inp)
+            print("output ROOT files:", self.root)
 
     def checkInputFiles(self):
         """Does some checks of the input files
@@ -79,13 +80,13 @@ class Converter:
 
         for f in self.inp:
             if not os.path.isfile(f):
-                print>>sys.stderr, "Error: %s does not exist" % f
+                print("Error: %s does not exist" % f, sys=sys.stderr)
                 return 1
 
         with open(self.inp[0]) as f:
             for line in f.readlines():
                 if re.search("\AFREE", line):
-                    print>>sys.sterr, "Error:\tFree-format input is not supported."
+                    print("Error:\tFree-format input is not supported.", sys=sys.stderr)
                     return 2
                     
         return 0
@@ -116,7 +117,7 @@ class Converter:
                 isname = True
 
             if len(opened):
-                print "Opened (named) units: ", opened
+                print("Opened (named) units: ", opened)
         inp.close()
     
         return opened
@@ -150,7 +151,7 @@ class Converter:
                             if not unit in e.units:
                                 e.addUnit(unit)
                         else:
-                            print>>sys.stderr, "Warning: ascii files not supported", unit, name
+                            print("Warning: ascii files not supported", unit, name, sys=sys.stderr)
         inp.close()
 
     def assignFileNames(self):
@@ -165,7 +166,7 @@ class Converter:
         """ Merge all data with standard FLUKA tools
         """
         if self.verbose:
-            print "Merging..."
+            print("Merging...")
         
         for e in self.estimators:
             if not len(e.units):
@@ -174,11 +175,11 @@ class Converter:
             for u in e.units:
                 temp_path = tempfile.mktemp()
                 if self.verbose:
-                    print e.name, temp_path
+                    print(e.name, temp_path)
                 with open(temp_path, "w") as tmpfile:
                     suwfile = self.getSuwFileName(e,u)
                     if self.verbose:
-                        print suwfile
+                        print(suwfile)
 
                     for f in e.units[u]:
                         tmpfile.write("%s\n" % f)
@@ -204,7 +205,7 @@ class Converter:
         """Convert merged files into ROOT
         """
         if self.verbose:
-            print "Converting..."
+            print("Converting...")
 
         v = "-v" if self.verbose else ""
             
@@ -225,15 +226,15 @@ class Converter:
                 self.out_root_files.append(rootfile)
 
         if self.verbose:
-            print "ROOT files produced: ", self.out_root_files
+            print("ROOT files produced: ", self.out_root_files)
 
         f = "-f" if self.overwrite else ""
-        command = "hadd %s %s %s" % (f, self.root, string.join(self.out_root_files)) + (" > /dev/null" if self.verbose else "")
+        command = "hadd %s %s %s" % (f, self.root, ' '.join(self.out_root_files)) + (" > /dev/null" if self.verbose else "")
         if self.verbose:
             printincolor(command)
         return_value = os.system(command)
         if return_value is 0:
-            command = "rm -f %s %s" % (v, string.join(self.out_root_files))
+            command = "rm -f %s %s" % (v, ' '.join(self.out_root_files))
             if self.verbose:
                 printincolor(command)
             return_value = os.system(command)

--- a/mctools/fluka/test/test.py
+++ b/mctools/fluka/test/test.py
@@ -3,6 +3,7 @@
 # https://github.com/kbat/mc-tools
 #
 
+from __future__ import print_function
 import re, sys
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -11,7 +12,7 @@ def compare(val1, val2, msg="", relPrec=1.0e-5):
     """ Compare two float variables with the given relative precision
     """
     if not ROOT.TMath.AreEqualRel(val1, val2, relPrec):
-        print >> sys.stderr, msg, "values do not match: ", val1, val2
+        print(msg, "values do not match: ", val1, val2, file=sys.stderr)
         return False
     else:
         return True
@@ -35,7 +36,7 @@ def usrtrack(rootfname, hname, lisfname):
             err = h.GetBinError(b)
             relerr = err/val*100 if val>0.0  else 0.0
             
-            #print b, w, h.GetBinLowEdge(b), h.GetBinLowEdge(b+1), val, relerr
+            #print(b, w, h.GetBinLowEdge(b), h.GetBinLowEdge(b+1), val, relerr)
             
             if not compare(float(w[2]), val, "Bin content") or \
                not compare(float(w[3]), relerr, "Relative bin error") or \
@@ -49,7 +50,7 @@ def usrtrack(rootfname, hname, lisfname):
 
     rootf.Close()
 
-    print>>sys.stderr, hname, "usrtrack test passed" if passed else "test failed"
+    print(hname, "usrtrack test passed" if passed else "test failed", file=sys.stderr)
 
     return passed
     

--- a/mctools/fluka/usbsuw2root.py
+++ b/mctools/fluka/usbsuw2root.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import sys, argparse
 from os import path
 from mctools import fluka
@@ -19,7 +20,7 @@ def main():
     args = parser.parse_args()
 
     if not path.isfile(args.usrbin):
-        print >> sys.stderr, "usrbin2root: File %s does not exist." % args.usrbin
+        print("usrbin2root: File %s does not exist." % args.usrbin, file=sys.stderr)
         return 1
 
     if args.root == "":
@@ -34,10 +35,10 @@ def main():
     
     if args.verbose:
         b.sayHeader()
-        print "\n%d tallies found:" % ND
+        print("\n%d tallies found:" % ND)
         for i in range(ND):
             b.say(i)
-            print ""
+            print("")
 
     fout = ROOT.TFile(rootFileName, "recreate")
     for i in range(ND):

--- a/mctools/fluka/ustsuw2root.py
+++ b/mctools/fluka/ustsuw2root.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import sys, argparse, struct
 from os import path
 import numpy as np
@@ -75,7 +76,7 @@ class Usrtrack(Data.Usrxxx):
             data = fortran.read(f)
             if data is None: break
             size = len(data)
-#            print "size: ", size
+#            print("size: ", size)
 
             if size == 14 and data[:10] == "STATISTICS":
                 self.statpos = f.tell()
@@ -110,7 +111,7 @@ class Usrtrack(Data.Usrxxx):
                 data = fortran.read(f)
                 det.ngroup = struct.unpack("=i",data[:4])[0]
                 det.egroup = struct.unpack("=%df"%(det.ngroup+1), data[4:])
-                print "Low energy neutrons scored with %d groups" % det.ngroup
+                print("Low energy neutrons scored with %d groups" % det.ngroup)
             else:
 		det.ngroup = 0
 		det.egroup = []
@@ -123,13 +124,13 @@ class Usrtrack(Data.Usrxxx):
     def printHeader(self, i):
         """ Prints the header """
         det = self.detector[i]
-        print "Detector:", det.name
-        print " binning type: ", det.type
-        print " distribution to be scored:", det.dist
-        print " region:", det.reg
-        print " volume:", det.volume
-        print " low energy neutrons:", det.lowneu
-        print " %g < E < %g GeV / %d bins; bin width: %g" % (det.elow, det.ehigh, det.ne, det.de)
+        print("Detector:", det.name)
+        print(" binning type: ", det.type)
+        print(" distribution to be scored:", det.dist)
+        print(" region:", det.reg)
+        print(" volume:", det.volume)
+        print(" low energy neutrons:", det.lowneu)
+        print(" %g < E < %g GeV / %d bins; bin width: %g" % (det.elow, det.ehigh, det.ne, det.de))
         
     def readStat(self, det,lowneu):
 	""" Read detector # det statistical data """
@@ -169,7 +170,7 @@ def main():
     args = parser.parse_args()
 
     if not path.isfile(args.usrtrack):
-        print >> sys.stderr, "ustsuw2root: File %s does not exist." % args.usrtrack
+        print("ustsuw2root: File %s does not exist." % args.usrtrack, file=sys.stderr)
         return 1
 
     if args.root == "":
@@ -186,7 +187,7 @@ def main():
         #b.sayHeader()
         for i in range(ND):
             b.printHeader(i)
-            print ""
+            print("")
 
     fout = ROOT.TFile(rootFileName, "recreate")
     for i in range(ND):
@@ -199,7 +200,7 @@ def main():
         hn = histN(det) # filled only if det.lowneu
             
         n = h.GetNbinsX()
-        print n, len(val), det.ne, val
+        print(n, len(val), det.ne, val)
 
         for i in range(det.ne):
             h.SetBinContent(i+1, val[i])

--- a/mctools/fluka/usxsuw2root.py
+++ b/mctools/fluka/usxsuw2root.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 import sys, argparse
 from os import path
 import numpy as np
@@ -15,7 +16,7 @@ def getType(n):
             for i3 in (0,1):
                 if (i1+10*i2+100*i3 == n):
                     return (i1,i2,i3) # i3 is irrelevant - use bin.fluence instead
-    print >> sys.stderr, "usrbdx2root: what(1) == %d undefined" % n
+    print("usrbdx2root: what(1) == %d undefined" % n, file=sys.stderr)
     sys.exit(1)
 
 def isLogE(x):
@@ -90,7 +91,7 @@ def main():
     args = parser.parse_args()
 
     if not path.isfile(args.usrbdx):
-        print >> sys.stderr, "usrbdx2root: File %s does not exist." % args.usrbdx
+        print("usrbdx2root: File %s does not exist." % args.usrbdx, file=sys.stderr)
         return 1
 
     if args.root == "":
@@ -105,10 +106,10 @@ def main():
     
     if args.verbose:
         b.sayHeader()
-        print "\n%d tallies found:" % ND
+        print("\n%d tallies found:" % ND)
         for i in range(ND):
             b.say(i)
-            print ""
+            print("")
 
     fout = ROOT.TFile(rootFileName, "recreate")
     for i in range(ND):

--- a/mctools/fluka/usxsuw2txt.py
+++ b/mctools/fluka/usxsuw2txt.py
@@ -2,14 +2,15 @@
 # $Id$
 # $URL$
 
+from __future__ import print_function, absolute_import
 import sys
-from fluka import USXSUW
+from .fluka import USXSUW
 
 def main():
     """Converts usxsuw binary output to ASCII"""
 
     if len(sys.argv) != 2:
-        print "Usage: usxsuw2txt.py usxsuw_file"
+        print("Usage: usxsuw2txt.py usxsuw_file")
         sys.exit(1)
 
     fin_name = sys.argv[1]

--- a/mctools/mcnp/mcnp.py
+++ b/mctools/mcnp/mcnp.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+from __future__ import print_function
 import re
 
 def getPar(masterfile, parname, pos=3):
@@ -11,7 +12,7 @@ def getPar(masterfile, parname, pos=3):
     for line in f.readlines():
         if re.search("\Ac THE%s" % parname, line, re.IGNORECASE):
             val = float(line.split()[pos])
-#            print line.strip(), val
+#            print(line.strip(), val)
     f.close()
     if val is "":
         raise IOError("Value of %s not found in %s" % (parname, masterfile))
@@ -30,12 +31,12 @@ def GetParticleNames(a):
              'pion+', 'pion-', 'pion0', 'kaon+', 'kaon-', 'K0short', 'K0long', 'D+', 'D0', 'Ds+', 'B+', 'B0', 'Bs0',
              'deuteron', 'triton', 'He3', 'He4', 'heavy ions']
     vals = []
-    print "a", a
+    print("a", a)
     if isinstance(a, int):
-        print a
+        print(a)
     else:
         for i in range(len(a)):
             if a[i] == 1: vals.append(names[i])
             elif a[i] != 0:
-                print 'strange values (not 0 or 1) found in the list of particles:', a
+                print('strange values (not 0 or 1) found in the list of particles:', a)
     return vals

--- a/mctools/mcnp/mcnp_source.py
+++ b/mctools/mcnp/mcnp_source.py
@@ -133,7 +133,7 @@ def main():
             ymin = -BB/2.0
             dy = BB/NY
             print("c     Full x-width:", AA, "     Number of x-bins:", NX)
-            print("c     Full y-width:", BB, "     Number of y-bins:", NYP
+            print("c     Full y-width:", BB, "     Number of y-bins:", NY)
             for x in range(NX+1):
                 if x == 0:
                     print("SI1  A  ", xmin + x*dx)

--- a/mctools/mcnp/mcnp_source.py
+++ b/mctools/mcnp/mcnp_source.py
@@ -10,9 +10,9 @@
 ### SOURCE GAUS SIGMAX SIGMAY NX NY TH ### - not yet implemented
 #
 
+from __future__ import print_function
 import fileinput
 import sys
-from string import join
 
 def getParabola(fullwidth, x):
     """
@@ -41,11 +41,11 @@ def main():
     is_fixed = False
     for line in fileinput.input():
         if line[0:23] == "### SOURCE 2D PARABOLIC":
-            print "c %s" % line.rstrip()
+            print("c %s" % line.rstrip())
             is_fixed = True
             words = line.split()
             if words[-1] != '###':
-                print >> sys.stderr, "ERROR in mcnp-source: wrong source definition format"
+                print("ERROR in mcnp-source: wrong source definition format", file=sys.stderr)
                 return 1
             AA = float(words[4])
             BB = float(words[5])
@@ -55,34 +55,34 @@ def main():
             dx = AA/NX
             ymin = -BB/2.0
             dy = BB/NY
-            print "c     Full x-width:", AA, "     Number of x-bins:", NX
-            print "c     Full y-width:", BB, "     Number of y-bins:", NY
+            print("c     Full x-width:", AA, "     Number of x-bins:", NX)
+            print("c     Full y-width:", BB, "     Number of y-bins:", NY)
             for x in range(NX+1):
                 if x == 0:
-                    print "SI1  A  ", xmin + x*dx
+                    print("SI1  A  ", xmin + x*dx)
                 else:
-                    print " "*8, xmin + x*dx
+                    print(" "*8, xmin + x*dx)
             for x in range(NX+1):
                 if x == 0:
-                    print "SP1     ", getParabola(AA, xmin+x*dx)
+                    print("SP1     ", getParabola(AA, xmin+x*dx))
                 else:
-                    print " "*8, getParabola(AA, xmin+x*dx)
+                    print(" "*8, getParabola(AA, xmin+x*dx))
             for y in range(NY+1):
                 if y == 0:
-                    print "SI2  A  ", ymin + y*dy
+                    print("SI2  A  ", ymin + y*dy)
                 else:
-                    print " "*8, ymin + y*dy
+                    print(" "*8, ymin + y*dy)
             for y in range(NY+1):
                 if y == 0:
-                    print "SP2     ", getParabola(BB, ymin+y*dy)
+                    print("SP2     ", getParabola(BB, ymin+y*dy))
                 else:
-                    print " "*8, getParabola(BB, ymin+y*dy)
+                    print(" "*8, getParabola(BB, ymin+y*dy))
         elif line[0:18] == "### SOURCE UNIFORM":
-            print "c %s" % line.rstrip()
+            print("c %s" % line.rstrip())
             is_fixed = True
             words = line.split()
             if words[-1] != '###':
-                print >> sys.stderr, "ERROR in mcnp-source: wrong source definition format"
+                print("ERROR in mcnp-source: wrong source definition format", file=sys.stderr)
                 return 2
             AA = float(words[3])
             BB = float(words[4])
@@ -92,37 +92,37 @@ def main():
             dx = AA/NX
             ymin = -BB/2.0
             dy = BB/NY
-            print "c     Full x-width:", AA, "     Number of x-bins:", NX
-            print "c     Full y-width:", BB, "     Number of y-bins:", NY
+            print("c     Full x-width:", AA, "     Number of x-bins:", NX)
+            print("c     Full y-width:", BB, "     Number of y-bins:", NY)
             for x in range(NX+1):
                 if x == 0:
-                    print "SI1  A  ", xmin + x*dx
+                    print("SI1  A  ", xmin + x*dx)
                 else:
-                    print " "*8, xmin + x*dx
+                    print(" "*8, xmin + x*dx)
             for x in range(NX+1):
                 if x == 0:
                     if getUniform(AA, xmin+x*dx) != 0:
-                        print >> sys.stderr, "First bin is not zero"
+                        print("First bin is not zero", file=sys.stderr)
                         return 3
-                    print "SP1     ", getUniform(AA, xmin+x*dx)
+                    print("SP1     ", getUniform(AA, xmin+x*dx))
                 else:
-                    print " "*8, getUniform(AA, xmin+x*dx)
+                    print(" "*8, getUniform(AA, xmin+x*dx))
             for y in range(NY+1):
                 if y == 0:
-                    print "SI2  A  ", ymin + y*dy
+                    print("SI2  A  ", ymin + y*dy)
                 else:
-                    print " "*8, ymin + y*dy
+                    print(" "*8, ymin + y*dy)
             for y in range(NY+1):
                 if y == 0:
-                    print "SP2     ", getUniform(BB, ymin+y*dy)
+                    print("SP2     ", getUniform(BB, ymin+y*dy))
                 else:
-                    print " "*8, getUniform(BB, ymin+y*dy)
+                    print(" "*8, getUniform(BB, ymin+y*dy))
         elif line[0:18] == "### SOURCE GAUS": # !!! not yet implemented - below is just copied from UNIFORM
-            print "c %s" % line.rstrip()
+            print("c %s" % line.rstrip())
             is_fixed = True
             words = line.split()
             if words[-1] != '###':
-                print >> sys.stderr, "ERROR in mcnp-source: wrong source definition format"
+                print("ERROR in mcnp-source: wrong source definition format", file=sys.stderr)
                 return 2
             SIGMAX = float(words[3])
             SIGMAY = float(words[4])
@@ -132,36 +132,36 @@ def main():
             dx = AA/NX
             ymin = -BB/2.0
             dy = BB/NY
-            print "c     Full x-width:", AA, "     Number of x-bins:", NX
-            print "c     Full y-width:", BB, "     Number of y-bins:", NY
+            print("c     Full x-width:", AA, "     Number of x-bins:", NX)
+            print("c     Full y-width:", BB, "     Number of y-bins:", NYP
             for x in range(NX+1):
                 if x == 0:
-                    print "SI1  A  ", xmin + x*dx
+                    print("SI1  A  ", xmin + x*dx)
                 else:
-                    print " "*8, xmin + x*dx
+                    print(" "*8, xmin + x*dx)
             for x in range(NX+1):
                 if x == 0:
                     if getUniform(AA, xmin+x*dx) != 0:
-                        print >> sys.stderr, "First bin is not zero"
+                        print("First bin is not zero", file=sys.stderr)
                         return 3
-                    print "SP1     ", getUniform(AA, xmin+x*dx)
+                    print("SP1     ", getUniform(AA, xmin+x*dx))
                 else:
-                    print " "*8, getUniform(AA, xmin+x*dx)
+                    print(" "*8, getUniform(AA, xmin+x*dx))
             for y in range(NY+1):
                 if y == 0:
-                    print "SI2  A  ", ymin + y*dy
+                    print("SI2  A  ", ymin + y*dy)
                 else:
-                    print " "*8, ymin + y*dy
+                    print(" "*8, ymin + y*dy)
             for y in range(NY+1):
                 if y == 0:
-                    print "SP2     ", getUniform(BB, ymin+y*dy)
+                    print("SP2     ", getUniform(BB, ymin+y*dy))
                 else:
-                    print " "*8, getUniform(BB, ymin+y*dy)
+                    print(" "*8, getUniform(BB, ymin+y*dy))
         else:
-            print line.rstrip()
+            print(line.rstrip())
     
     if is_fixed == False:
-        print >> sys.stderr, "WARNING in mcnp-source.py: source definition not found"
+        print("WARNING in mcnp-source.py: source definition not found", sys.stderr)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/mctools/mcnp/mcplotkeys.py
+++ b/mctools/mcnp/mcplotkeys.py
@@ -7,19 +7,19 @@ import sys
 class XDoTool:
     def __init__(self, title):
         print("# ", title)
-        print('"xdotool',)
+        print('"xdotool', end='')
 
     def MouseMove(self, x, y):
-        print("mousemove %d %d" % (x, y),)
+        print("mousemove %d %d" % (x, y), end='')
 
     def MouseMove1(self, coord):
         return self.MouseMove(coord[0], coord[1])
 
     def Click(self, button, repeat=1):
         if repeat==1:
-            print("click %d" % button,)
+            print("click %d" % button, end='')
         else:
-            print("click --repeat %d %d" % (repeat, button),)
+            print("click --repeat %d %d" % (repeat, button), end='')
 
     def SetKey(self, title, key):
         print('"')
@@ -28,7 +28,7 @@ class XDoTool:
         print("")
 
     def Restore(self):
-        print("restore",)
+        print("restore", end='')
 
     def Redraw(self):
         self.MouseMove(100,100)

--- a/mctools/mcnp/mcplotkeys.py
+++ b/mctools/mcnp/mcplotkeys.py
@@ -1,33 +1,34 @@
 #! /usr/bin/python -W all
 # Generates xbindkeys configuration file for MCNP viewer
 
+from __future__ import print_function
 import sys
 
 class XDoTool:
     def __init__(self, title):
-        print "# ", title
-        print '"xdotool',
+        print("# ", title)
+        print('"xdotool',)
 
     def MouseMove(self, x, y):
-        print "mousemove %d %d" % (x, y),
+        print("mousemove %d %d" % (x, y),)
 
     def MouseMove1(self, coord):
         return self.MouseMove(coord[0], coord[1])
 
     def Click(self, button, repeat=1):
         if repeat==1:
-            print "click %d" % button,
+            print("click %d" % button,)
         else:
-            print "click --repeat %d %d" % (repeat, button),
+            print("click --repeat %d %d" % (repeat, button),)
 
     def SetKey(self, title, key):
-        print '"'
-        print " "*3, key
-        print "# ", title
-        print ""
+        print('"')
+        print(" "*3, key)
+        print("# ", title)
+        print("")
 
     def Restore(self):
-        print "restore",
+        print("restore",)
 
     def Redraw(self):
         self.MouseMove(100,100)

--- a/mctools/mcnp/mctal.py
+++ b/mctools/mcnp/mctal.py
@@ -3,7 +3,8 @@
 # https://github.com/kbat/mc-tools
 #
 
-import sys, re, string, math
+from __future__ import print_function
+import sys, re, math
 import numpy as np
 
 #############################################################################################################################
@@ -39,9 +40,9 @@ class Header:
 		        print ("title: %s" % self.title)
 
 		        if self.ntal>1:
-				print self.ntal, 'tallies:', self.ntals
+				print(self.ntal, 'tallies:', self.ntals)
 	        	else:
-				print self.ntal, 'tally:', self.ntals
+				print(self.ntal, 'tally:', self.ntals)
 
 
 		        if self.npert != 0:
@@ -474,13 +475,13 @@ class MCTAL:
 		"""This function calls the functions getHeaders and parseTally in order to read the entier MCTAL file."""
 
 		if self.verbose:
-			print "\n\033[1;34m[Parsing file: %s...]\033[0m" % self.mctalFileName
+			print("\n\033[1;34m[Parsing file: %s...]\033[0m" % self.mctalFileName)
 
 		self.getHeaders()
 		self.getTallies()
 
 		if self.thereAreNaNs and self.verbose:
-			print >> sys.stderr, "\n \033[1;30mThe MCTAL file contains one or more tallies with NaN values. Flagged.\033[0m\n"
+			print("\n \033[1;30mThe MCTAL file contains one or more tallies with NaN values. Flagged.\033[0m\n", file=sys.stderr)
 
 		self.mctalFile.close()
 		return self.tallies
@@ -513,12 +514,12 @@ class MCTAL:
 		self.header.ntal = int(self.line[1])
 
 		if self.header.ntal == 0:
-			print >> sys.stderr, "\n \033[1;31mNo tallies in this MCTAL file. Exiting.\033[0m\n"
+			print("\n \033[1;31mNo tallies in this MCTAL file. Exiting.\033[0m\n", file=sys.stderr)
 			sys.exit(1)
 
 		if len(self.line) == 4:
 			self.header.npert = int(self.line[3])
-			print >> sys.stderr, "\n \033[1;31mMCTAL file with perturbation card. Not supported. Exiting.\033[0m\n"
+			print("\n \033[1;31mMCTAL file with perturbation card. Not supported. Exiting.\033[0m\n", file=sys.stderr)
 			sys.exit(1)
 
 		self.line = self.mctalFile.readline().split()
@@ -544,7 +545,7 @@ class MCTAL:
 		tally = Tally(int(self.line[1]),self.verbose)
 
 		if self.verbose:
-			print " \033[33mParsing tally: %5d\033[0m" % (tally.tallyNumber)
+			print(" \033[33mParsing tally: %5d\033[0m" % (tally.tallyNumber))
 
 		tally.typeNumber = int(self.line[2])
 		if len(self.line) == 4: tally.detectorType = int(self.line[3])
@@ -726,17 +727,17 @@ class MCTAL:
 		nErg   = tally.getNbins("e")
 		nTim   = tally.getNbins("t")
 
-		for c in xrange(nCells):
-			for d in xrange(nDir):
-				for u in xrange(nUsr):
-					for s in xrange(nSeg):
-						for m in xrange(nMul):
-							for a in xrange(nCos): # a is for Angle...forgive me
-								for e in xrange(nErg):
-									for t in xrange(nTim):
-										for k in xrange(nCorc):
-											for j in xrange(nCorb):
-												for i in xrange(nCora):
+		for c in range(nCells):
+			for d in range(nDir):
+				for u in range(nUsr):
+					for s in range(nSeg):
+						for m in range(nMul):
+							for a in range(nCos): # a is for Angle...forgive me
+								for e in range(nErg):
+									for t in range(nTim):
+										for k in range(nCorc):
+											for j in range(nCorb):
+												for i in range(nCora):
 													if (f > nFld): # f is for Field...again, forgive me
 														del Fld
 														del self.line
@@ -772,7 +773,7 @@ class MCTAL:
 			self.line = self.mctalFile.readline().strip()
 			while "tally" not in self.line and len(self.line) != 0:
 				if "kcode" in self.line:
-					print >> sys.stderr, "\n \033[1;31m Tally with KCODE card. Not supported. Exiting.\033[0m\n"
+					print("\n \033[1;31m Tally with KCODE card. Not supported. Exiting.\033[0m\n", file=sys.stderr)
 					sys.exit(1)
 
 				self.line = self.line.split()

--- a/mctools/mcnp/mctal2root.py
+++ b/mctools/mcnp/mctal2root.py
@@ -3,9 +3,10 @@
 # https://github.com/kbat/mc-tools
 #
 
-import sys, argparse, string
+from __future__ import print_function, absolute_import
+import sys, argparse
 from os import path
-from mctal import MCTAL
+from .mctal import MCTAL
 import numpy as np
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -25,7 +26,7 @@ def main():
 	arguments = parser.parse_args()
 
 	if not path.isfile(arguments.mctal):
-		print >> sys.stderr, "mctal2root: File %s does not exist." % arguments.mctal
+		print("mctal2root: File %s does not exist." % arguments.mctal, file=sys.stderr)
 		return 1
 
 	m = MCTAL(arguments.mctal,arguments.verbose)
@@ -33,7 +34,7 @@ def main():
 	T = m.Read()
 
 	if m.thereAreNaNs:
-		print >> sys.stderr, " \033[1;30mOne or more tallies contain NaN values. Conversion will succeed anyway.\033[0m"
+		print(" \033[1;30mOne or more tallies contain NaN values. Conversion will succeed anyway.\033[0m", file=sys.stderr)
 
 	if arguments.root == "":
 		rootFileName = "%s%s" % (arguments.mctal,".root")
@@ -43,7 +44,7 @@ def main():
 	rootFile = ROOT.TFile(rootFileName,"RECREATE");
 
 	if arguments.verbose:
-		print "\n\033[1;34m[Converting...]\033[0m"
+		print("\n\033[1;34m[Converting...]\033[0m")
 
 	for tally in T:
 
@@ -86,7 +87,7 @@ def main():
 			binsMin = np.array( [0.,        0.,      0.,      0.,      0.,      0.,      0.,      0.,      0.,       0.,       0.] )
 			binsMax = np.array( [1.,        1.,      1.,      1.,      1.,      1.,      1.,      1.,      1.,       1.,       1.] )
 
-			hs = ROOT.THnSparseF("%s%d" % (tallyLetter, tally.tallyNumber), string.join(tally.tallyComment.tolist()).strip(), 11, bins, binsMin, binsMax)
+			hs = ROOT.THnSparseF("%s%d" % (tallyLetter, tally.tallyNumber), ' '.join(tally.tallyComment.tolist()).strip(), 11, bins, binsMin, binsMax)
 
 		else:
 
@@ -94,7 +95,7 @@ def main():
 			binsMin = np.array( [0,        0,      0,      0,      0,      0,      0,      0], dtype=float)
 			binsMax = np.array( [1,        1,      1,      1,      1,      1,      1,      1], dtype=float)
 
-			hs = ROOT.THnSparseF("%s%d" % (tallyLetter, tally.tallyNumber), string.join(tally.tallyComment.tolist()).strip(), 8, bins, binsMin, binsMax)
+			hs = ROOT.THnSparseF("%s%d" % (tallyLetter, tally.tallyNumber), ' '.join(tally.tallyComment.tolist()).strip(), 8, bins, binsMin, binsMax)
 
 
 
@@ -137,7 +138,7 @@ def main():
 													val = tally.getValue(f,d,u,s,m,c,e,t,i,j,k,0)
 													err = tally.getValue(f,d,u,s,m,c,e,t,i,j,k,1)
 
-													#print "%5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %13.5E" % (f+1,d+1,u+1,s+1,m+1,c+1,e+1,t+1,i+1,j+1,k+1,val)
+													#print("%5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %5d - %13.5E" % (f+1,d+1,u+1,s+1,m+1,c+1,e+1,t+1,i+1,j+1,k+1,val))
 
 													if tally.mesh == True:
 														hs.SetBinContent(np.array([f+1,d+1,u+1,s+1,m+1,c+1,e+1,t+1,i+1,j+1,k+1],dtype=np.dtype('i4')), val)
@@ -155,11 +156,11 @@ def main():
 		hs.Write()
 
 		if arguments.verbose:
-			print " \033[33mTally %5d saved\033[0m" % (tally.tallyNumber)
+			print(" \033[33mTally %5d saved\033[0m" % (tally.tallyNumber))
 
 
 	rootFile.Close()
-	print "\n\033[1;34mROOT file saved to:\033[1;32m %s\033[0m\n" % (rootFileName)
+	print("\n\033[1;34mROOT file saved to:\033[1;32m %s\033[0m\n" % (rootFileName))
 
 
 if __name__ == "__main__":

--- a/mctools/mcnp/mctaltest.py
+++ b/mctools/mcnp/mctaltest.py
@@ -1,7 +1,8 @@
 #! /usr/bin/python -W all
+from __future__ import absolute_import
 import sys, argparse
-from mctal import MCTAL
-from testsuite import TestSuite
+from .mctal import MCTAL
+from .testsuite import TestSuite
 
 def main():
 	"""

--- a/mctools/mcnp/roottest.py
+++ b/mctools/mcnp/roottest.py
@@ -1,7 +1,8 @@
 #! /usr/bin/python -W all
+from __future__ import print_function, absolute_import
 import sys, argparse
-from mctal import MCTAL
-from roottestsuite import RootTest
+from .mctal import MCTAL
+from .roottestsuite import RootTest
 
 def main():
 	"""
@@ -31,7 +32,7 @@ def main():
 
 	else:
 
-		print >> sys.stderr, " \033[31mTest on MCTAL file %s was skipped due to NaN values\033[0m\n" % arguments.mctal_file
+		print(" \033[31mTest on MCTAL file %s was skipped due to NaN values\033[0m\n" % arguments.mctal_file, file=sys.stderr)
 		sys.exit(1)
 
 

--- a/mctools/mcnp/roottestsuite.py
+++ b/mctools/mcnp/roottestsuite.py
@@ -1,10 +1,11 @@
 #! /usr/bin/python -W all
+from __future__ import print_function, absolute_import
 import time
 import subprocess
 import tempfile
 import os,sys,math
 import numpy as np
-from testsuite import FormatStrings
+from .testsuite import FormatStrings
 import ROOT
 
 #############################################################################################################################
@@ -47,7 +48,7 @@ class RootTest:
 
 		binIndexList = ("f","d","u","s","m","c","e","t","i","j","k")
 		binNumberList = (tally.nCells,tally.nDir,tally.nUsr,tally.nSeg,tally.nMul,tally.nCos,tally.nErg,tally.nTim,tally.meshInfo[1],tally.meshInfo[2],tally.meshInfo[3])
-		binList = dict(zip(binIndexList,binNumberList))
+		binList = dict(list(zip(binIndexList,binNumberList)))
 
 		for axis in binIndexList:
 
@@ -184,7 +185,7 @@ class RootTest:
 						self.rootOutFile.write(fs.binValuesLine % axisValues[kk])
 					except:
 						if self.verbose:
-							print >> sys.stderr, "\033[1;30m %s " % hs.GetTitle() + "k = %5d " % kk + "Index out of range for axis %3d. (Skipping without errors)\033[0m" % (a+1)
+							print("\033[1;30m %s " % hs.GetTitle() + "k = %5d " % kk + "Index out of range for axis %3d. (Skipping without errors)\033[0m" % (a+1), file=sys.stderr)
 						break
 					if (k+1) > 0 and (k+1) % 6 == 0 and (k+1) != nB:
 						self.rootOutFile.write("\n")
@@ -241,25 +242,25 @@ class RootTest:
 				else:
 					pre_text = "\033[33m"
 					post_text = "\033[0m"
-				print "%s Testing with relative error: %s%s" % (pre_text,self.precision[i],post_text)
+				print("%s Testing with relative error: %s%s" % (pre_text,self.precision[i],post_text))
 				if i == 2:
-					print >> sys.stderr,  "\033[1;31m Try:\033[0m\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1],self.mctalOutFile.name,self.rootOutFile.name)
+					print("\033[1;31m Try:\033[0m\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1],self.mctalOutFile.name,self.rootOutFile.name), file=sys.stderr)
 					f.write("\tndiff-2.00 --relative-error %s %s %s\n" % (self.precision[1],self.mctalOutFile.name,self.rootOutFile.name))
 					f.flush
 			if not subprocess.call(['ndiff-2.00','--relative-error', self.precision[i], '--quiet', self.mctalOutFile.name, self.rootOutFile.name],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT):
 				if self.verbose:
-					print "\n\033[1;32m[TEST PASSED]\033[0m\n"
+					print("\n\033[1;32m[TEST PASSED]\033[0m\n")
 				if i < 2:
 					os.remove(self.mctalOutFile.name)
 					os.remove(self.rootOutFile.name)
 				f.close()
 				return 0
 		if self.verbose:
-			print >> sys.stderr, "\n\033[1;31m[TEST FAILED]\033[0m"
-			print >> sys.stderr,  "\033[1;31m Original MCTAL:\033[31m %s - \033[1;31mTest MCTAL:\033[31m %s\033[0m" % (self.mctalOutFile.name,self.rootOutFile.name)
-			print >> sys.stderr,  "\033[1;31m Try:\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1], self.mctalOutFile.name,self.rootOutFile.name)
+			print("\n\033[1;31m[TEST FAILED]\033[0m", file=sys.stderr)
+			print("\033[1;31m Original MCTAL:\033[31m %s - \033[1;31mTest MCTAL:\033[31m %s\033[0m" % (self.mctalOutFile.name,self.rootOutFile.name), file=sys.stderr)
+			print("\033[1;31m Try:\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1], self.mctalOutFile.name,self.rootOutFile.name), file=sys.stderr)
 		else:
-			print >> sys.stderr, "\033[1;31mFAILED FOR FILE: \033[0m%s" % (self.mctalOutFile.name)
-			print >> sys.stderr,  "\033[1;31m Try:\033[0m\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1],self.mctalOutFile.name,self.rootOutFile.name)
+			print("\033[1;31mFAILED FOR FILE: \033[0m%s" % (self.mctalOutFile.name), file=sys.stderr)
+			print("\033[1;31m Try:\033[0m\033[31m ndiff-2.00 --relative-error %s %s %s\033[0m\n" % (self.precision[1],self.mctalOutFile.name,self.rootOutFile.name), file=sys.stderr)
 		f.close()
 		return 1

--- a/mctools/mcnp/ssw.py
+++ b/mctools/mcnp/ssw.py
@@ -2,6 +2,7 @@
 # https://github.com/kbat/mc-tools
 # 
 
+from __future__ import print_function
 import sys, math, struct
 
 #-------------------------------------------------------------------------------
@@ -12,7 +13,7 @@ def fortranRead(f):
         blen = f.read(4)
         if len(blen)==0: return None
         (size,) = struct.unpack("=i", blen)
-#	print "length:", size
+#	print("length:", size)
         data  = f.read(size)
         blen2 = f.read(4)
         if blen != blen2:
@@ -28,7 +29,7 @@ def unpackArray(data):
 
 
 def unsupported():
-	print >> sys.stderr, "Your MCNP(X) version is not supported."
+	print("Your MCNP(X) version is not supported.", file=sys.stderr)
 	sys.exit(1)
 
 
@@ -82,15 +83,15 @@ class SSW:
         # This is according to Esben's subs.f, but the format seems to be wrong
         #        (kods, vers, lods, idtms, probs, aids, knods) = struct.unpack("=8s5s8s19s19s80s24s", data) # ??? why 24s ???
         # This has been modified to fix the format:
-#        print "size: ", size
+#        print("size: ", size)
  	if size == 8: # mcnp 6
 		(tmpi0) = struct.unpack("8s", data) # wssa file type
-#		print "type_of_rssa:", tmpi0
+#		print("type_of_rssa:", tmpi0)
 		data = fortranRead(self.file)
 		(self.kods, self.vers, self.lods, self.idtms, self.aids, self.knods) = struct.unpack("=8s5s28s18s80si", data)
 		self.vers = self.vers.strip()
 		if self.vers not in  ("6", "6.mpi"):
-			print "'%s'" % self.vers
+			print("'%s'" % self.vers)
 			raise IOError("ssw.py: format error %s")
 	elif size==163:
 		(self.kods, self.vers, self.lods, self.idtms, self.probs, self.aids, self.knods) = struct.unpack("=8s5s28s19s19s80si", data) # length=160
@@ -98,24 +99,24 @@ class SSW:
 	elif size==167: # like in the Tibor's file with 2.7.0
 		tmp = float(0)
 		(self.kods, self.vers, self.lods, self.idtms, self.probs, self.aids, self.knods, tmp) = struct.unpack("=8s5s28s19s19s80sif", data) # length=160
-#		print "tmp: ", tmp
+#		print("tmp: ", tmp)
 		self.vers = self.vers.strip()
 	else:
 		unsupported()
 
-        print "Code:\t\t%s" % self.kods
-        print "Version:\t%s" % self.vers
-        print "Date:\t\t%s" % self.lods
-        print "Machine designator:", self.idtms
-        print "Problem id:\t%s" % self.probs
-        print "Title:\t\t%s" % self.aids.strip()
-#        print "knods:", self.knods
+        print("Code:\t\t%s" % self.kods)
+        print("Version:\t%s" % self.vers)
+        print("Date:\t\t%s" % self.lods)
+        print("Machine designator:", self.idtms)
+        print("Problem id:\t%s" % self.probs)
+        print("Title:\t\t%s" % self.aids.strip())
+#        print("knods:", self.knods)
 
 	supported_mcnp_versions = ['2.6.0', '26b', '2.7.0', '6', '6.mpi']
-#        print self.kods.strip(), self.vers
+#        print(self.kods.strip(), self.vers)
 	if self.kods.strip() not in ['mcnpx', 'mcnp'] or self.vers not in supported_mcnp_versions:
-		print >> sys.stderr, "WARNING: This version of MCNPx (%s) might not be supported." % self.vers
-		print >> sys.stderr, "\t The code was developed for SSW files produced by these MCNPX versions:", supported_mcnp_versions
+		print("WARNING: This version of MCNPx (%s) might not be supported." % self.vers, file=sys.stderr)
+		print("\t The code was developed for SSW files produced by these MCNPX versions:", supported_mcnp_versions, file=sys.stderr)
 
         data = fortranRead(self.file)
         size = len(data)
@@ -125,19 +126,19 @@ class SSW:
 	# niss - number of histories in RSSA data
 	# niwr - number of cells in RSSA data (np1<0)
 	# mipts - Partikel der Quelldatei = incident particles (?) (np1<0)
-#	print "size", size
+#	print("size", size)
 	if self.vers in ("6", "6.mpi"):
 #		(np1,nrss,self.nrcd,njsw,niss,self.probs) = struct.unpack("=5i12s", data)
 		(np1,tmp1, nrss, tmp2, tmp3, njsw, self.nrcd,niss) = struct.unpack("=4i4i", data)
-		print "probs",np1, tmp1, tmp2, tmp3, nrss, self.nrcd, njsw, niss
+		print("probs",np1, tmp1, tmp2, tmp3, nrss, self.nrcd, njsw, niss)
 	elif size==20:
 		(np1,nrss,self.nrcd,njsw,niss) = struct.unpack("=5i", data)
 	elif size==40: # Tibor with 2.7.0
 		(np1,tmp4,nrss,tmp2,self.nrcd, tmp1, njsw, tmp3, niss, tmp5) = struct.unpack("=5i5i", data)
-#		print "A", np1,nrss, niss, tmp2, self.nrcd
-#		print "B", tmp1, njsw, tmp3, tmp4, tmp5
+#		print("A", np1,nrss, niss, tmp2, self.nrcd)
+#		print("B", tmp1, njsw, tmp3, tmp4, tmp5)
 	else:
-                print self.vers, size
+                print(self.vers, size)
 		unsupported()
 
 	self.N = abs(np1)
@@ -154,40 +155,40 @@ class SSW:
         self.nrcdo = self.nrcd
         np1o = np1
 
-#        print "Number of tracks:", nevt
+#        print("Number of tracks:", nevt)
         self.nevt = nevt
         tmp = []
         if np1 < 0:
             np1 = abs(np1)
             data = fortranRead(self.file)
-#            print len(data)
+#            print(len(data))
             # (niwr, mipts,tmp
             tmp = struct.unpack("=%di" % int(len(data)/4) ,data) # ??? why tmp ???
             niwr = tmp[0]
             mipts = tmp[1]
-#            print niwr,mipts,tmp
+#            print(niwr,mipts,tmp)
             
         if self.nrcd != 6 and self.nrcd != 10: self.nrcd = self.nrcd - 1
 
         for i in range(njsw+niwr):
             data = fortranRead(self.file)
             size = len(data)
-#            print "size", size
+#            print("size", size)
             tmpii, tmpkk, tmpnn, tmp = struct.unpack("=3i%ds" % int(size-12), data) #  12=3*4 due to '3i'
-#            print "tmpnn", tmpnn, len(tmp)
+#            print("tmpnn", tmpnn, len(tmp))
 	    # if self.vers == '2.7.0':
-	    # 	    print "" # struct.unpack("2f", tmp)
+	    # 	    print("") # struct.unpack("2f", tmp)
 	    # elif self.vers == '2.6.0':
-	    # 	    print "" # struct.unpack("3f", tmp)
+	    # 	    print("") # struct.unpack("3f", tmp)
 	    # else:
-	    # 	    print "This MCNP version is not supported:", self.vers
+	    # 	    print("This MCNP version is not supported:", self.vers)
 #		    sys.exit(1)
             self.isurfs.append(tmpii)
             self.kstpps.append(tmpkk)
             self.ntppsp.append(tmpnn)
 
         data = fortranRead(self.file)
-#        print len(data), (2+4*mipts), (njsw+niwr)
+#        print(len(data), (2+4*mipts), (njsw+niwr))
 #        for i in range(2+4*mipts):
 #            for j in range(njsw+niwr):
 #                a = 1 # !!! to be implemented
@@ -199,7 +200,7 @@ class SSW:
         data = fortranRead(self.file)
 	if self.vers in ("6", "6.mpi"):
 		size = len(data)
-#		print "here", self.nrcd, size
+#		print("here", self.nrcd, size)
 		size = size/8
 		ssb = struct.unpack("=%dd" % int(size), data)
 	else:

--- a/mctools/mcnp/ssw2root.py
+++ b/mctools/mcnp/ssw2root.py
@@ -2,8 +2,9 @@
 # $Id: ssw2root.py 250 2015-05-04 09:35:55Z batkov $
 # $URL: https://github.com/kbat/mc-tools/blob/master/mcnp/ssw2root.py $
 
+from __future__ import absolute_import
 import sys, argparse
-from ssw import SSW
+from .ssw import SSW
 # from ROOT import TFile, TTree, gROOT
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True

--- a/mctools/mcnp/ssw2txt.py
+++ b/mctools/mcnp/ssw2txt.py
@@ -2,8 +2,9 @@
 # $Id$
 # $URL$
 
+from __future__ import print_function, absolute_import
 import sys, argparse
-from ssw import SSW
+from .ssw import SSW
 
 def main():
     """
@@ -28,7 +29,7 @@ def main():
 
     ssw = SSW(fin_name)
 
-    print "history id weight energy time x y z wx wy k"
+    print("history id weight energy time x y z wx wy k")
 
     for i in range(ssw.nevt):
         ssb = ssw.readHit()
@@ -43,7 +44,7 @@ def main():
         wx = ssb[8] # x-direction cosine
         wy = ssb[9] # y-direction cosine
         k = ssb[10] # cosine of angle between track and normal to surface jsu (in MCNPX it is called cs)
-        print history, id, weight, energy, time, x, y, z, wx, wy, k
+        print(history, id, weight, energy, time, x, y, z, wx, wy, k)
 
 
 if __name__ == "__main__":

--- a/mctools/mcnp/testsuite.py
+++ b/mctools/mcnp/testsuite.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python -W all
+from __future__ import print_function
 import subprocess
 import tempfile
 import os, sys
@@ -68,7 +69,7 @@ class TestSuite:
                         headerLine = fs.headerLine_250
 
 		if self.mctalObject.header.ver != "2.7.0" and self.mctalObject.header.ver != "2.5.0" and self.mctalObject.header.ver != "":
-			print "\033[1;31m[* WARNING *]\033[0m\033[31m This MCNPX version is not officially supported. Results could be wrong.\033[0m"
+			print("\033[1;31m[* WARNING *]\033[0m\033[31m This MCNPX version is not officially supported. Results could be wrong.\033[0m")
 
 		if len(self.mctalObject.header.probid) == 0:
 			probid = str("").rjust(19)
@@ -266,17 +267,17 @@ class TestSuite:
 
 		if not subprocess.call(['diff', '-bi', self.mctalObject.mctalFileName, self.outFile.name], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT):
 			if self.verbose:
-				print "\n\033[1;32m[TEST PASSED]\033[0m"
+				print("\n\033[1;32m[TEST PASSED]\033[0m")
 			os.remove(self.outFile.name)
 			return 0
 		else:
 			if self.verbose:
-				print >> sys.stderr, "\n\033[1;31m[TEST FAILED]\033[0m"
-				print >> sys.stderr,  "\033[1;31mOriginal MCTAL:\033[0m\033[31m %s - \033[0m\033[1;31mTest MCTAL:\033[0m\033[31m %s\033[0m" % (self.mctalObject.mctalFileName,self.outFile.name)
-				print >> sys.stderr,  "\033[1;31mTry:\033[0m\033[31m diff -b -i %s %s\033[0m\n" % (self.mctalObject.mctalFileName,self.outFile.name)
+				print("\n\033[1;31m[TEST FAILED]\033[0m", file=sys.stderr)
+				print("\033[1;31mOriginal MCTAL:\033[0m\033[31m %s - \033[0m\033[1;31mTest MCTAL:\033[0m\033[31m %s\033[0m" % (self.mctalObject.mctalFileName,self.outFile.name), file=sys.stderr)
+				print("\033[1;31mTry:\033[0m\033[31m diff -b -i %s %s\033[0m\n" % (self.mctalObject.mctalFileName,self.outFile.name), file=sys.stderr)
 			else:
-				print >> sys.stderr, "\033[1;31mFAILED FOR FILE: \033[0m\033[31m%s\033[0m" % (self.mctalObject.mctalFileName)
-				print >> sys.stderr,  "\033[1;31mTry:\033[0m\033[31m diff -b -i %s %s\033[0m\n" % (self.mctalObject.mctalFileName,self.outFile.name)
+				print("\033[1;31mFAILED FOR FILE: \033[0m\033[31m%s\033[0m" % (self.mctalObject.mctalFileName), file=sys.stderr)
+				print("\033[1;31mTry:\033[0m\033[31m diff -b -i %s %s\033[0m\n" % (self.mctalObject.mctalFileName,self.outFile.name), file=sys.stderr)
 			return 1
 
 		

--- a/mctools/mcnp/vol.py
+++ b/mctools/mcnp/vol.py
@@ -16,16 +16,16 @@ def main():
     args = parser.parse_args()
 
     a = args.vol.split()
-    vols = dict(zip(map(int, a[0::2]), map(float, a[1::2])))
+    vols = dict(list(zip(list(map(int, a[0::2])), list(map(float, a[1::2])))))
 
     s = "vol"
     c0 = 0 # number of previous cell in the 'vols' dict
     dist = 0 # distance from the current cell to the previous one in the 'vols' dict
-    for i,c in enumerate(sorted(vols.iterkeys())):
+    for i,c in enumerate(sorted(vols.keys())):
         v = vols[c]
         dist=c-c0
     
-        #    print "%d:" % i, c,v, dist
+        #    print("%d:" % i, c,v, dist)
     
         if dist==1:
             s += " %g " % v
@@ -37,7 +37,7 @@ def main():
 
     s += " 1 %dr" % (args.N-c-3)
 
-    print textwrap.fill(s, width=80, subsequent_indent=" "*7)
+    print(textwrap.fill(s, width=80, subsequent_indent=" "*7))
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/mctools/mcnp/zoom.py
+++ b/mctools/mcnp/zoom.py
@@ -2,7 +2,7 @@
 
 
 
-
+from __future__ import print_function
 import sys, re
 import argparse
 
@@ -33,32 +33,32 @@ def main():
 
             for i,w in enumerate(words):
                 if re.search("^bas", w):
-                    cmd['bas'] = map(float, words[i+1:i+7])
+                    cmd['bas'] = list(map(float, words[i+1:i+7]))
                     if plane is False: bas = True # basis was before plane cuts
                 elif re.search("^or", w):
-                    cmd['or'] = map(float, words[i+1:i+4])
+                    cmd['or'] = list(map(float, words[i+1:i+4]))
                 elif re.search("^ex", w):
                     try: # both x and y scales are given
-                        cmd['ex'] = map(float, words[i+1:i+3])
+                        cmd['ex'] = list(map(float, words[i+1:i+3]))
                         continue
                     except ValueError: # just 1 scale is given
-                        cmd['ex'] = map(float, words[i+1:i+2])
+                        cmd['ex'] = list(map(float, words[i+1:i+2]))
                 elif re.search("^lab", w):
-                    cmd['label'] = map(int, map(float, words[i+1:i+3])) #+ [words[i+3]]
+                    cmd['label'] = list(map(int, map(float, words[i+1:i+3]))) #+ [words[i+3]]
                 elif re.search("^p[xyz]", w):
                     cmd[w] = [float(words[i+1])]
                     if bas is False: plane = True # plane cuts were before basis
                 elif re.search("^legend", w):
                     cmd[w] = [words[i+1]]
                 elif w == "scale":
-                    print w
+                    print(w)
                     if int(words[i+1]): # no need to put 'scale 0'
                         cmd[w] = [words[i+1]]
                 elif w in ("mesh"):
                     if int(words[i+1])==1: # no need to put 'mesh 1'
                         cmd[w] = [words[i+1]]
 
-    print bas, plane
+    print(bas, plane)
 
     if plane: # bas was first
         keys = ('bas', 'or', 'ex', 'px', 'py', 'pz', 'label', 'mesh', 'legend', 'scale')

--- a/mctools/mctools.py
+++ b/mctools/mctools.py
@@ -158,7 +158,7 @@ class Material:
         print("  Atomic weight: ", self.GetA(), "g/mole")
         print("  Isotopes:")
         for j,i in enumerate(self.isotopes):
-#            print(" "*2, self.nn[j],)
+#            print(" "*2, self.nn[j], end='')
             i.Print()
             print("   Volume fraction in %s: %g" % (self.name, self.GetVolumeFraction(i)))
 

--- a/mctools/mctools.py
+++ b/mctools/mctools.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -W all
 
+from __future__ import print_function
 # from scipy import constants
 import subprocess, os, sys
 from math import sqrt
@@ -43,12 +44,12 @@ def checkPaths(dirs, files, verbose=True):
     for d in dirs:
         if not os.path.isdir(d):
             if verbose:
-                print>>sys.stderr, d, "does not exist"
+                print(d, "does not exist", file=sys.stderr)
             return 1
 
     for f in files:
         if not os.path.isfile(f): 
-            print>>sys.stderr, f, "does not exist"
+            print(f, "does not exist", file=sys.stderr)
             return 2
     return 0
 
@@ -105,20 +106,20 @@ class Compound:
         for i,v in enumerate(af):
             af[i] = v/s
 
-        return dict(zip(iname, af))
+        return dict(list(zip(iname, af)))
 
     def PrintAtomicFractions(self):
-        for i,f in sorted(self.GetAtomicFractions().iteritems()):
-            print i,f
-        print "Density: ", -self.GetDensity()
+        for i,f in sorted(self.GetAtomicFractions().items()):
+            print(i,f)
+        print("Density: ", -self.GetDensity())
 
     def Print(self):
-        print "Compound:", self.name
-        print " Density:", self.GetDensity()
+        print("Compound:", self.name)
+        print(" Density:", self.GetDensity())
         for j,m in enumerate(self.materials):
-            print "", self.vf[j], "%"
+            print("", self.vf[j], "%")
             m.Print()
-        print " Mass fractions:"
+        print(" Mass fractions:")
         self.GetAtomicFractions()
 
 class Material:
@@ -152,14 +153,14 @@ class Material:
         return vf
 
     def Print(self):
-        print " Material:", self.name
-        print "  Density:", self.density
-        print "  Atomic weight: ", self.GetA(), "g/mole"
-        print "  Isotopes:"
+        print(" Material:", self.name)
+        print("  Density:", self.density)
+        print("  Atomic weight: ", self.GetA(), "g/mole")
+        print("  Isotopes:")
         for j,i in enumerate(self.isotopes):
-#            print " "*2, self.nn[j],
+#            print(" "*2, self.nn[j],)
             i.Print()
-            print "   Volume fraction in %s: %g" % (self.name, self.GetVolumeFraction(i))
+            print("   Volume fraction in %s: %g" % (self.name, self.GetVolumeFraction(i)))
 
 class Isotope:
     """ Isotopes form material """
@@ -168,6 +169,6 @@ class Isotope:
         self.A = A # atomic weight
 
     def Print(self):
-        print "\t%s \t A = %g" % (self.name, self.A)
+        print("\t%s \t A = %g" % (self.name, self.A))
 
 ### END MIXTURES ###

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -7,9 +7,10 @@
 #  Usage: angel2root.py file.dat
 #
 
-import sys, re, string, argparse
+from __future__ import print_function, absolute_import
+import sys, re, argparse
 from array import array
-from phits import TallyOutputParser
+from .phits import TallyOutputParser
 import ROOT
 # The line below is needed to prevent command-line arguments from
 # stolen by PyROOT and handed to TApplication
@@ -19,7 +20,7 @@ from ROOT import ROOT, TH1F, TH2F, TFile, TObjArray, TGraphErrors
 """
 def isData(line):
     words = line.strip()
-#    print words
+#    print(words)
     for w in words:
         try:
             float(w)
@@ -106,7 +107,7 @@ class Angel:
             if pageSepRE.search(modLine):
                 numNewpages += 1
                 pageSepLineLST.append(idx)
-        if DEBUG: print "pageSepLineLST: ", pageSepLineLST
+        if DEBUG: print("pageSepLineLST: ", pageSepLineLST)
 
         ##################################################
         # Separate each page into a tuple and
@@ -129,7 +130,7 @@ class Angel:
             line.strip()
             if re.search("title = ", line):
                 words = line.split()
-                self.title = string.join(words[2:])
+                self.title = ' '.join(words[2:])
                 continue
             if re.search("mesh = ", line):
                 words = line.split()
@@ -139,19 +140,19 @@ class Angel:
                 for a in line.split()[2:]:
                     if a == '#': break
                     self.axis.append(a)
-                if DEBUG: print "axis: ", self.axis
+                if DEBUG: print("axis: ", self.axis)
                 continue
             if re.search("reg = ", line):
                 for r in line.split()[2:]:
                     if r == '#': break
                     self.reg.append(r)
-                if DEBUG: print "reg: ", self.reg
+                if DEBUG: print("reg: ", self.reg)
                 continue
             if re.search("^n[eartxyz] = ", line.strip()): # !!! make sence if we specify number of bins but not the bin width
                 words = line.split()
                 self.dict_nbins[words[0]] = int(words[2])
                 self.last_nbins_read = words[0]
-                if DEBUG: print "dict_nbins:", self.dict_nbins
+                if DEBUG: print("dict_nbins:", self.dict_nbins)
                 continue
             if re.search("#    data = ", line):
                 self.dict_edges_array[self.last_nbins_read] = self.GetBinEdges(iline)
@@ -160,18 +161,18 @@ class Angel:
                 words = line.split()
 # this loop is needed in case we define particles in separate lines as shown on page 121 of the Manual. Otherwise we could have used 'self.part = words[2:]'
                 for w in words[2:]: self.part.append(w)
-                if DEBUG: print "particles:", self.part
+                if DEBUG: print("particles:", self.part)
                 continue
             if re.search("output = ", line):
                 words = line.split()
                 self.output = words[2]
-                self.output_title = string.join(words[4:])
+                self.output_title = ' '.join(words[4:])
                 if self.unit_title != None: self.ztitle = self.output_title + " " + self.unit_title
                 continue
             if re.search("unit = ", line):
                 words = line.split()
                 self.unit = words[2]
-                self.unit_title = string.join(words[6:])
+                self.unit_title = ' '.join(words[6:])
                 if self.output_title != None: self.ztitle = self.output_title + " " + self.unit_title
                 continue
          
@@ -185,22 +186,22 @@ class Angel:
                 line.strip()
                 if re.search("^x:", line):
                     words = line.split()
-                    self.xtitle = string.join(words[1:])
-                    if DEBUG: print "xtitle:", self.xtitle
+                    self.xtitle = ' '.join(words[1:])
+                    if DEBUG: print("xtitle:", self.xtitle)
                     continue
                 elif re.search("^y:", line):
                     words = line.split()
-                    self.ytitle = string.join(words[1:])
-                    if DEBUG: print "ytitle:", self.ytitle
+                    self.ytitle = ' '.join(words[1:])
+                    if DEBUG: print("ytitle:", self.ytitle)
                     continue
                 elif re.search("^z:", line):
                     if not re.search("xorg", line):
-                        print line
-                        print "new graph - not yet implemented"
+                        print(line)
+                        print("new graph - not yet implemented")
                     continue
                 elif re.search("'no. =", line): # subtitles of 2D histogram
-                    self.subtitles.append(string.join(line[line.find(',')+1:].split()).replace("\'", '').strip())
-                    if DEBUG: print "subtitle:", self.subtitles
+                    self.subtitles.append(' '.join(line[line.find(',')+1:].split()).replace("\'", '').strip())
+                    if DEBUG: print("subtitle:", self.subtitles)
 
             # second scan: extract data.
             #              scan only within the current page, pass the corresponding
@@ -213,7 +214,7 @@ class Angel:
                 igline = iline + pageSepLineLST[npage-1] + 1
                 if re.search("^h", line):
                     if re.search("^h: n", line): # !!! We are looking for 'h: n' instead of 'h' due to rz-plots.
-                        if DEBUG: print "one dimentional graph section"
+                        if DEBUG: print("one dimentional graph section")
                         self.Read1DHist(igline)
                         continue
                     elif re.search("h:              x", line):
@@ -221,20 +222,20 @@ class Angel:
                         continue
                     elif re.search("^h[2dc]:", line):
                         if DEBUG:
-                            if re.search("^h2", line): print "h2: two dimentional contour plot section"
-                            if re.search("^hd", line): print "hd: two dimentional cluster plot section"
-                            if re.search("^hc", line): print "hc: two dimentional colour cluster plot section"
+                            if re.search("^h2", line): print("h2: two dimentional contour plot section")
+                            if re.search("^hd", line): print("hd: two dimentional cluster plot section")
+                            if re.search("^hc", line): print("hc: two dimentional colour cluster plot section")
                         self.Read2DHist(igline)
                         continue
                     elif 'reg' in self.axis: # line starts with 'h' and axis is 'reg' => 1D histo in region mesh. For instance, this is whe case with [t-deposit] tally and mesh = reg.
                         self.Read1DHist(igline)
                         continue
 
-#        print self.dict_edges_array
+#        print(self.dict_edges_array)
         if self.is1D():
-            if DEBUG: print "1D"
+            if DEBUG: print("1D")
         else:
-            if DEBUG: print "2D"
+            if DEBUG: print("2D")
 #            self.Make2Dfrom1D()
 
 
@@ -244,7 +245,7 @@ class Angel:
             fout.Close()
             self.return_value = 0
         else:
-            print "Have not found any histograms/graphs in this file"
+            print("Have not found any histograms/graphs in this file")
             self.return_value = 1
 
     def is1D(self):
@@ -254,7 +255,7 @@ class Angel:
         nn1 = 0 # number of cases when number of bins is not 1
         for key in self.dict_nbins:
             if int(self.dict_nbins[key])>1: nn1 += 1
-        if DEBUG: print "nn1:", nn1
+        if DEBUG: print("nn1:", nn1)
         
         if nn1 <= 1:
             return True
@@ -262,20 +263,20 @@ class Angel:
             return False
 
     # def GetBinEdgesOrig(self, iline):
-    #     print "iline:", iline
+    #     print("iline:", iline)
     #     edges = []
     #     for line in self.lines[iline+1:]:
-    #         print "line: ", line
+    #         print("line: ", line)
     #         if line[0] == '#':
     #             words =  line[1:].split()
-    #             print words
+    #             print(words)
     #             for w in words:
     #                 edges.append(w)
     #         else: break
     #     if len(edges)-1 != self.dict_nbins[self.last_nbins_read]:
-    #         print "ERROR in GetBinEdges: wrong edge or bin number:", len(edges)-1, self.dict_nbins[self.last_nbins_read]
+    #         print("ERROR in GetBinEdges: wrong edge or bin number:", len(edges)-1, self.dict_nbins[self.last_nbins_read])
     #         sys.exit(1)
-    #    # print 'edges:', edges
+    #    # print('edges:', edges)
     #     return tuple(edges)
 
 
@@ -284,7 +285,7 @@ class Angel:
         for line in self.lines[iline+1:]:
             words =  line.split()
             if line[0] == '#': # if the distribution type is 1 or 2 then '#' is used
-                if DEBUG: print words[1:]
+                if DEBUG: print(words[1:])
                 for w in words[1:]:
                     edges.append(w)
             elif is_float(words[0]):
@@ -292,9 +293,9 @@ class Angel:
                     edges.append(w)
             else: break
         if len(edges)-1 != self.dict_nbins[self.last_nbins_read]:
-            print "ERROR in GetBinEdges: wrong edge or bin number:", len(edges)-1, self.dict_nbins[self.last_nbins_read]
+            print("ERROR in GetBinEdges: wrong edge or bin number:", len(edges)-1, self.dict_nbins[self.last_nbins_read])
             sys.exit(1)
-       # print 'edges:', edges
+       # print('edges:', edges)
         return tuple(edges)
 
     def GetNhist(self, line):
@@ -320,7 +321,7 @@ class Angel:
                 else:
                     self.subtitles.append('')
 ###        if re.search("^n", words[1]) and re.search("^x", words[2]) and re.search("^y", words[3]) and re.search("^n", words[4]):
-        if DEBUG: print "Section Header: 1D histo", nhists, self.subtitles
+        if DEBUG: print("Section Header: 1D histo", nhists, self.subtitles)
         return nhists
 
     def Read1DHist(self, iline):
@@ -328,11 +329,11 @@ class Angel:
         Read 1D histogram section
         """
         nhist = self.GetNhist(self.lines[iline]) # number of histograms to read in the current section
-        if DEBUG: print 'nhist: ', nhist
+        if DEBUG: print('nhist: ', nhist)
         isCharge = False
         if re.search("x-0.5", self.lines[iline].split()[1]):
             isCharge = True # the charge-mass-chart distribution, x-axis is defined by the 1st column only
-            if DEBUG: print "isCharge = True"
+            if DEBUG: print("isCharge = True")
         xarray = []
         xmax = None
         data = {}     # dictionary for all histograms in the current section
@@ -348,7 +349,7 @@ class Angel:
             if line == '': break
             elif re.search("^#", line): continue
             words = line.split()
-#            if DEBUG: print words
+#            if DEBUG: print(words)
             if isCharge:
                 xarray.append(float(words[0])-0.5)
                 xmax = float(words[0])+0.5
@@ -371,7 +372,7 @@ class Angel:
         nbins = len(xarray)
         xarray.append(xmax)
 
-#        if DEBUG: print "data: ", data
+#        if DEBUG: print("data: ", data)
 
         for ihist in range(nhist):
             if self.subtitles[ihist]: subtitle = ' - ' + self.subtitles[ihist]
@@ -458,10 +459,10 @@ class Angel:
         line = self.lines[iline].replace(" =", "=") # sometimes Angel writes 'y=' and sometimes 'y ='
         words = line.split()
         if len(words) != 15:
-            print words
-            print len(words)
+            print(words)
+            print(len(words))
             sys.exit("Read2DHist: format error")
-#        print words
+#        print(words)
 
         dy = float(words[6])
         ymin = float(words[2])
@@ -478,7 +479,7 @@ class Angel:
             else:
                 ymin,ymax = ymax+dy/2.0, ymin-dy/2.0
         ny = abs(int(round((ymax-ymin)/dy)))
-        if DEBUG: print "y:", dy, ymin, ymax, ny
+        if DEBUG: print("y:", dy, ymin, ymax, ny)
 
         dx = float(words[13])
         xmin = float(words[9])
@@ -488,7 +489,7 @@ class Angel:
         else:
             xmin,xmax = xmax-dx/2.0, xmin+dx/2.0
         nx = int(round((xmax-xmin)/dx))
-        if DEBUG: print "x:", dx, xmin, xmax, nx
+        if DEBUG: print("x:", dx, xmin, xmax, nx)
 
         data = []
         for line in self.lines[iline+1:]:
@@ -496,13 +497,13 @@ class Angel:
             if line == '': break
             elif re.search("^#", line): continue
             words = line.split()
-#            if DEBUG: print "words: ", words
+#            if DEBUG: print("words: ", words)
             for w in words:
                 if w == 'z:':
-#                    if DEBUG: print "this is a color palette -> exit"
+#                    if DEBUG: print("this is a color palette -> exit")
                     return # this was a color palette
                 data.append(float(w))
-#        if DEBUG: print data
+#        if DEBUG: print(data)
        
         # self.ihist+1 - start from ONE as in Angel - easy to compare
         h = TH2F("h%d" % (self.ihist+1), "%s - %s;%s;%s;%s" % (self.title, self.subtitles[self.ihist], self.xtitle, self.ytitle, self.ztitle), nx, xmin, xmax, ny, ymin, ymax)
@@ -523,11 +524,11 @@ class Angel:
         for i in range(1,nhist):
             h = self.histos[i]
             if nbins0 != self.histos[i].GetNbinsX():
-                print "not the same bin number", i
+                print("not the same bin number", i)
                 return false
             for bin in range(nbins0):
                 if self.histos[0].GetBinLowEdge(i+1) != self.histos[i].GetBinLowEdge(i+1):
-                    print "Low edge differ for bin %d of histo %d" % (bin, i)
+                    print("Low edge differ for bin %d of histo %d" % (bin, i))
                     return False
         return True
 
@@ -548,7 +549,7 @@ class Angel:
         """
         # check if all histograms have the same x-range:
         if not self.isSameXaxis():
-            print "ERROR in Make2Dfrom1D: x-axes are different"
+            print("ERROR in Make2Dfrom1D: x-axes are different")
             sys.exit(1)
 
         # guess which dict_edges_array correspond to 1D histos
@@ -563,17 +564,17 @@ class Angel:
                 second_dimention_nbins = nbins
         
         if second_dimention:
-            if DEBUG: print "the second dimention is", second_dimention, second_dimention_nbins
+            if DEBUG: print("the second dimention is", second_dimention, second_dimention_nbins)
         else:
-            if DEBUG: print "Second dimention was not found based on the number of bins -> bin edges comparing needed"
+            if DEBUG: print("Second dimention was not found based on the number of bins -> bin edges comparing needed")
             sys.exit(3)
 
 #        h2 = TH2F("hall%s" % second_dimention, "", nbins0, 0, 1, 20, 0, 1)
         
-#        if DEBUG: print array('f', self.getXarray(self.histos[0]))
+#        if DEBUG: print(array('f', self.getXarray(self.histos[0])))
         second_dimention_xarray = []
         for w in self.dict_edges_array[second_dimention]: second_dimention_xarray.append(float(w))
-#        for w in self.dict_edges_array[second_dimention]: if DEBUG: print float(w)
+#        for w in self.dict_edges_array[second_dimention]: if DEBUG: print(float(w))
 #        array('f', second_dimention_xarray)
 
         h2 = TH2F("hall%s" % second_dimention, "%s;%s;%s;%s" % (self.histos[0].GetYaxis().GetTitle(), self.histos[0].GetXaxis().GetTitle(), "Time [nsec]", self.histos[0].GetYaxis().GetTitle()),
@@ -610,7 +611,7 @@ def main():
     fname_out = re.sub("\....$", ".root", fname_in)
     if fname_in == fname_out:
         fname_out = fname_in + ".root"
-    print fname_in, "->" ,fname_out
+    print(fname_in, "->" ,fname_out)
 
     angel =  Angel(fname_in, fname_out,avBitSet=args.average)
     

--- a/mctools/phits/phits.py
+++ b/mctools/phits/phits.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python -W all
 
-import sys, re, string
+from __future__ import print_function
+import sys, re
 from math import *
 
 try:
@@ -16,7 +17,7 @@ mcnp_phits_particles = {"n" : "neutron", "h":"proton", "/":"pion+ pion-", "z":"p
 
 def ReadSection(line):
     """ Section is a part of the ANGEL input file starting from alphabet characters with colon ':' line H:"""
-    print "ReadSection", line
+    print("ReadSection", line)
     sys.exit(0)
 
 # exception classes
@@ -168,7 +169,7 @@ class TallyOutputParser:
             if line == '' or line[0] == '#':
                 if isData  and line == '':
                     isData = False
-                    print "data end"
+                    print("data end")
                     self.data[self.nhist] = data[:] # [:] makes a slice (copy) of the tuple since we are going to delete it:
                     del data[:]
                     self.subtitle[self.nhist] = subtitle
@@ -184,12 +185,12 @@ class TallyOutputParser:
 #            words = line.split()
 #            for iw, w in enumerate(words):
 #                if w == '#':
-#                    line = string.join(words[:iw])
+#                    line = ' '.join(words[:iw])
             
             mo = self.SECTCRE.match(line)
             if mo:
                 sectname = mo.group('header')
-#                print sectname
+#                print(sectname)
                 if sectname in self.sections:
                     cursect = self.sections[sectname]
                 else:
@@ -218,7 +219,7 @@ class TallyOutputParser:
 #                    try:
 #                        cursect[optname]
 #                    except KeyError:
-#                        print "current section already has option ", optname
+#                        print("current section already has option ", optname)
 #                    else:
                     cursect[optname] = optval
                     # set the axis - we will need it below to parse the data format
@@ -227,17 +228,17 @@ class TallyOutputParser:
 
                 if re.search("^h", line) and not isData:
                     ReadSection(line)
-                    print "data start"
+                    print("data start")
                     isData = True
                     continue
 
                 if isData:
-                    print "data: ", line
+                    print("data: ", line)
                     words = line.split()
                     try:
                         float(words[0])
                     except ValueError:
-#                        print "Ignoring line: ", line
+#                        print("Ignoring line: ", line)
                         continue
                     
 
@@ -260,8 +261,8 @@ class TallyOutputParser:
   # if any parsing errors occurred, raise an exception
 #        if e:
 #            raise e
-        print self.nhist, "histos found"
-        print "xarray", self.xarray
+        print(self.nhist, "histos found")
+        print("xarray", self.xarray)
         self.file.close()
 
     def get(self, section, option):
@@ -284,8 +285,8 @@ class Input:
 
     def FixLine1(self, line):
         # we sort the dictionary by the key length, so we replace the longer keys first
-        # in order avoid mistakes like AA = 5, AAB = 6 -> '5B'
-        for key, value in sorted(self.pars.iteritems(), key=lambda(k,v):(len(k),v), reverse=True):
+        # in order to avoid mistakes like AA = 5, AAB = 6 -> '5B'
+        for key, value in sorted(iter(self.pars.items()), key=lambda k,v: (len(k),v), reverse=True):
             line = line.replace("%s" % key, "%s" % str(value))
 
 #            line = line.replace(" %s " % i, " %s " % str(self.pars[i]))
@@ -308,7 +309,7 @@ class Input:
         line = self.FixLine(line)
         if comment:
             line = line + " $ " + comment
-        print >> self.inp, line
+        print(line, file=self.inp)
 
     def Section(self, sectname):
         self.Line('[%s]' % sectname)
@@ -332,7 +333,7 @@ class Input:
             try:
                 value = eval(value)
             except NameError:
-                print "ERROR: cannot eval value '%s'" % value
+                print("ERROR: cannot eval value '%s'" % value)
                 sys.exit(1)
 
         name = name.strip()
@@ -340,7 +341,7 @@ class Input:
         if value_orig != value:
             value_orig = value_orig + " = " + str(value)
         if comment: value_orig = str(value_orig) + "\t(%s)" % str(comment)
-        print >> self.inp, "c %s = %s" % (name, value_orig)
+        print("c %s = %s" % (name, value_orig), file=self.inp)
         
 
     def Get(self, name):

--- a/mctools/phits/rotate3dshow.py
+++ b/mctools/phits/rotate3dshow.py
@@ -20,7 +20,7 @@
 # https://github.com/kbat/mc-tools
 
 
-import re, sys, string, argparse, os
+import re, sys, argparse, os
 
 def main():
     """

--- a/mctools/phits/submit.py
+++ b/mctools/phits/submit.py
@@ -7,12 +7,12 @@
 #      submit.sh inp.phits 100 llsubmit ../single.job
 # 
 
+from __future__ import print_function
 from sys import argv, exit
 from os  import system
-from string import join
 
 if len(argv)<4:
-	print "wrong usage"
+	print("wrong usage")
 	exit(100)
 
 command = argv[3:]
@@ -21,22 +21,22 @@ inp = argv[1]
 prefix = 'dir'
 
 if system("test -e %s" % inp):
-	print "input file '%s' not found" % inp
+	print("input file '%s' not found" % inp)
 	exit(1)
 
 if njobs<=0:
-	print "number of jobs must be positive: %d" % njobs
+	print("number of jobs must be positive: %d" % njobs)
 	exit(2)
 
 if system("grep rseed %s" % inp):
-	print "Error: rseed must be negative in the input file '%s'" % inp
+	print("Error: rseed must be negative in the input file '%s'" % inp)
 	exit(3)
 
 for i in range(njobs):
 	dir = "%s%.3d" % (prefix, i)
-	print dir
+	print(dir)
 	if system("mkdir %s" % dir): exit(4)
         if system("cp %s %s" % (inp, dir)): exit(6)
-        if system("cd %s && %s" % (dir, join(command))):
-		print "Error: can't submit job"
+        if system("cd %s && %s" % (dir, ' '.join(command))):
+		print("Error: can't submit job")
 		exit(7)

--- a/mctools/phits/wwinp2phits.py
+++ b/mctools/phits/wwinp2phits.py
@@ -4,9 +4,9 @@
 #
 #
 
+from __future__ import print_function, absolute_import
 import re, sys
-from string import join
-from phits import mcnp_phits_particles as particle
+from .phits import mcnp_phits_particles as particle
 
 def getCells(fname):
     """
@@ -41,7 +41,7 @@ def get_weight_titles(ni):
     tmparray = ["     reg"]
     for i in range(ni):
         tmparray.append("%9s%d" % ('ww', i+1))
-    return join(tmparray)
+    return ' '.join(tmparray)
 
 def print_weights(weights, cells):
     """
@@ -57,8 +57,8 @@ def print_weights(weights, cells):
         for i in intervals:
             tmparray.append(weights[i][icell-1])
         if len(tmparray) != 0:
-            print "    %4d" % cells[icell-1], join(tmparray)
-#        outarray.append("    %4d %s" % (icell, join(tmparray)))
+            print("    %4d" % cells[icell-1], ' '.join(tmparray))
+#        outarray.append("    %4d %s" % (icell, ' '.join(tmparray)))
         del tmparray[:]
 #    return outarray
 
@@ -79,17 +79,17 @@ def my_print_weights(weights, cells):
         for i in intervals:
             tmparray.append(weights[i][icell-1])
         if len(tmparray) != 0:
-            the_line = "    %4d %s"  % (cells[icell-1], join(tmparray))
-            print the_line
-            if cells[icell-1] == 242: w442 = "    %4d %s"  % (442, join(tmparray))
-            if cells[icell-1] == 260: w460 = "    %4d %s"  % (460, join(tmparray))
-            if cells[icell-1] == 260: w461 = "    %4d %s"  % (461, join(tmparray))
-            if cells[icell-1] == 260: w462 = "    %4d %s"  % (462, join(tmparray))
+            the_line = "    %4d %s"  % (cells[icell-1], ' '.join(tmparray))
+            print(the_line)
+            if cells[icell-1] == 242: w442 = "    %4d %s"  % (442, ' '.join(tmparray))
+            if cells[icell-1] == 260: w460 = "    %4d %s"  % (460, ' '.join(tmparray))
+            if cells[icell-1] == 260: w461 = "    %4d %s"  % (461, ' '.join(tmparray))
+            if cells[icell-1] == 260: w462 = "    %4d %s"  % (462, ' '.join(tmparray))
         del tmparray[:]
-    print w442
-    print w460
-    print w461
-    print w462
+    print(w442)
+    print(w460)
+    print(w461)
+    print(w462)
 #    return outarray
 
 def main():
@@ -108,7 +108,7 @@ Usage: wwin2phits input.phits wwinp [ > wwinp.phits ]
     i = 0 # energy/time interval
 
     if len(sys.argv) != 3:
-        print main.__doc__
+        print(main.__doc__)
         sys.exit(1)
 
     cells = getCells(sys.argv[1])
@@ -128,10 +128,10 @@ Usage: wwin2phits input.phits wwinp [ > wwinp.phits ]
             wwn = False
 
 
-            print "\n[Weight Window]"
-            tmp = join(line.split(":")[1]).split()
+            print("\n[Weight Window]")
+            tmp = ' '.join(line.split(":")[1]).split()
             p = tmp[0]
-            print "  part = %s" % particle[p]
+            print("  part = %s" % particle[p])
             del energies[:]
             for w in line.split()[1:]:
                 energies.append(w)
@@ -148,9 +148,9 @@ Usage: wwin2phits input.phits wwinp [ > wwinp.phits ]
             weights[i] = []
 
             if i == 1:
-                print "   eng = %d" % len(energies)
-                print "         %s" % join(energies)
-                print get_weight_titles(len(energies))
+                print("   eng = %d" % len(energies))
+                print("         %s" % ' '.join(energies))
+                print(get_weight_titles(len(energies)))
 
             for w in line.split()[1:]:
                 weights[i].append(w)

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys, os, subprocess
 
 # prepare setuptools environment
 try:
     from setuptools import setup, find_packages
 except ImportError:
-    print "Could NOT import setuptools, try ez_setup..."
+    print("Could NOT import setuptools, try ez_setup...")
     try:
         from ez_setup import use_setuptools
         use_setuptools()
         from setuptools import setup, find_packages
     except ImportError:
-        print "Could NOT import either setuptools or ez_setup, GIVE UP!"
-        print "Download ez_setup.py e.g. " \
-            "from https://bootstrap.pypa.io/ez_setup.py,"
-        print "place it in the same directory as setup.py, and try again... "
+        print("Could NOT import either setuptools or ez_setup, GIVE UP!")
+        print("Download ez_setup.py e.g. " \
+            "from https://bootstrap.pypa.io/ez_setup.py,")
+        print("place it in the same directory as setup.py, and try again... ")
         sys.exit(1)
 
 setup(


### PR DESCRIPTION
Hi!

It's high time to move to Python 3, and I've modified the tools so that they run in both Python2 and Python3.  
Exceptions are files in mctools/fluka/flair directory; these are not modified.
**Only** `angel2root` and the related files were **tested**, w/ root 6.16/00...

Please review/test them and pull if it's OK.
Kazuyoshi

1. `from __future__ import print_function` and the use of
   `print()`.

2. `from __future__ import absolute_import` and import of
   local files.

3. use of `input()` (Python 3) or `raw_input()` as `input()` (Python 2).

4. redundant protection of `zip()` and `map()` by the use of `list()`.

5. use of `exec()` function instead of exec statement.

6. avoid the use of `string.join()`, which are removed in Python 3.

7. `xrange()` -> `range()`.

8. `dict.iterkeys()` -> `dict.keys()`.

9. `lambda` statement, not function.