### PR TITLE
To avoid cppyy.ll.SegmentationViolation in doing self.histos.Write()

### DIFF
--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -251,7 +251,7 @@ class Angel:
 
         if self.histos.GetEntries():
             fout = TFile(self.fname_out, "recreate")
-            self.histos.Write()
+            fout.Write()
             fout.Close()
             self.return_value = 0
         else:

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -225,17 +225,20 @@ class Angel:
                 if re.search("^h", line):
                     if re.search("^h: [nx]", line): # !!! We are looking for 'h: n' instead of 'h' due to rz-plots.
                         if DEBUG: print("one dimentional graph section")
-                        self.Read1DHist(igline)
+                        tmp_h = self.Read1DHist(igline)
+                        self.histos.Add(tmp_h)
                         continue
                     elif re.search("h:              x", line):
-                        self.Read1DGraphErrors(igline)
+                        tmp_g = self.Read1DGraphErrors(igline)
+                        self.histos.Add(tmp_g)
                         continue
                     elif re.search("^h[2dc]:", line):
                         if DEBUG:
                             if re.search("^h2", line): print("h2: two dimentional contour plot section")
                             if re.search("^hd", line): print("hd: two dimentional cluster plot section")
                             if re.search("^hc", line): print("hc: two dimentional colour cluster plot section")
-                        self.Read2DHist(igline)
+                        tmp_h = self.Read2DHist(igline)
+                        self.histos.Add(tmp_h)
                         continue
                     elif 'reg' in self.axis: # line starts with 'h' and axis is 'reg' => 1D histo in region mesh. For instance, this is whe case with [t-deposit] tally and mesh = reg.
                         self.Read1DHist(igline)
@@ -246,12 +249,13 @@ class Angel:
             if DEBUG: print("1D")
         else:
             if DEBUG: print("2D")
-#            self.Make2Dfrom1D()
+#            tmp_h2 = self.Make2Dfrom1D()
+#            self.histos.Add(tmp_h2)
 
 
         if self.histos.GetEntries():
             fout = TFile(self.fname_out, "recreate")
-            fout.Write()
+            self.histos.Write()
             fout.Close()
             self.return_value = 0
         else:
@@ -405,7 +409,7 @@ class Angel:
                     h.GetXaxis().SetBinLabel(i+1, bin_labels[i])
                 h.GetXaxis().SetTitle("Region number")
 
-            self.histos.Add(h)
+            return h
         del self.subtitles[:]
 
     def Read1DGraphErrors(self, iline):
@@ -448,7 +452,7 @@ class Angel:
                 g.SetPoint(i, x, y)
                 g.SetPointError(i, 0, ey*y)
 
-            self.histos.Add(g)
+            return g
         del self.subtitles[:]
 
 
@@ -600,7 +604,7 @@ class Angel:
                 h2.SetBinError(binx+1, biny+1, h1.GetBinError(binx+1))
 
 
-        self.histos.Add(h2)
+        return h2
 
 
 


### PR DESCRIPTION
With recent root versions (specifically, [version 6.40](https://root.cern/doc/v640/release-notes.html)), `angel2root` SegFaults at `self.histos.Write()` as the following (curious enough, when tracing with pdb, `next` over the instruction segfalts but `step` does NOT!).  I think that it might have something to do with [the recent changes in Python Interface](https://root.cern/doc/v640/release-notes.html#python-interface).
The change I made was just a quick fix; I don't think I know the real cause of the problem.  It may really be because of the lack of some arguments in `TCollection::Write()` as the Traceback part at the bottom suggests...
But do we really need to `Write()` the `TObjArray` object `histos` instead to `Write()` the output file?

```
$ angel2root gFlux_r600_20260522.out
gFlux_r600_20260522.out -> gFlux_r600_20260522.root
 *** Break *** segmentation violation



===========================================================
There was a crash (kSigSegmentationViolation).
This is the entire stack trace of all threads:
===========================================================
#0  __internal_syscall_cancel (a1=3443827, a2=a2
entry=140724987577880, a3=a3
entry=0, a4=a4
entry=0, a5=a5
entry=0, a6=a6
entry=0, nr=61) at cancellation.c:44
#1  0x0000146751c750b4 in __syscall_cancel (a1=<optimized out>, a2=a2
entry=140724987577880, a3=a3
entry=0, a4=a4
entry=0, a5=a5
entry=0, a6=a6
entry=0, nr=61) at cancellation.c:75
#2  0x0000146751ce552f in __GI___wait4 (pid=<optimized out>, stat_loc=stat_loc
entry=0x7ffd16e54618, options=options
entry=0, usage=usage
entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#3  0x0000146751ce557b in __GI___waitpid (pid=<optimized out>, stat_loc=stat_loc
entry=0x7ffd16e54618, options=options
entry=0) at waitpid.c:38
#4  0x0000146751c3500d in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:172
#5  0x00001466fd1e1376 in TUnixSystem::Exec (this=0x56435d9de330, shellcmd=0x5643655559b0 "/home/furutaka/res/root-master-20260527-dbg/etc/gdb-backtrace.sh 3443799 1>&2") at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:2133
#6  0x00001466fd1e1c40 in TUnixSystem::StackTrace (this=0x56435d9de330) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:2424
#7  0x00001466fd8fd0ad in (anonymous namespace)::do_trace (sig=1) at /home/furutaka/work/root/root.git/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:274
#8  0x00001466fd8fd128 in (anonymous namespace)::TExceptionHandlerImp::HandleException (this=0x564360e4ede0, sig=1) at /home/furutaka/work/root/root.git/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:287
#9  0x00001466fd1e5805 in TUnixSystem::DispatchSignals (this=0x56435d9de330, sig=kSigSegmentationViolation) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:3646
#10 0x00001466fd1dd448 in SigHandler (sig=kSigSegmentationViolation) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:410
#11 0x00001466fd1e5708 in sighandler (sig=11) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:3622
#12 <signal handler called>
#13 0x00001466fd105219 in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:689
#14 0x00001466fd1052bc in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:705
#15 0x00001466fc3e506c in ?? ()
#16 0x0000000000000000 in ?? ()
===========================================================


The lines below might hint at the cause of the crash. If you see question
marks as part of the stack trace, try to recompile with debugging information
enabled and export CLING_DEBUG=1 environment variable before running.
You may get help by asking at the ROOT forum https://root.cern/forum
preferably using the command (.forum bug) in the ROOT prompt.
Only if you are really convinced it is a bug in ROOT then please submit a
report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
the ROOT prompt. Please post the ENTIRE stack trace
from above as an attachment in addition to anything else
that might help us fixing this issue.
===========================================================
#13 0x00001466fd105219 in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:689
#14 0x00001466fd1052bc in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:705
#15 0x00001466fc3e506c in ?? ()
#16 0x0000000000000000 in ?? ()
===========================================================


 *** Break *** segmentation violation



===========================================================
There was a crash (kSigSegmentationViolation).
This is the entire stack trace of all threads:
===========================================================
#0  __internal_syscall_cancel (a1=3443972, a2=a2
entry=140724987577880, a3=a3
entry=0, a4=a4
entry=0, a5=a5
entry=0, a6=a6
entry=0, nr=61) at cancellation.c:44
#1  0x0000146751c750b4 in __syscall_cancel (a1=<optimized out>, a2=a2
entry=140724987577880, a3=a3
entry=0, a4=a4
entry=0, a5=a5
entry=0, a6=a6
entry=0, nr=61) at cancellation.c:75
#2  0x0000146751ce552f in __GI___wait4 (pid=<optimized out>, stat_loc=stat_loc
entry=0x7ffd16e54618, options=options
entry=0, usage=usage
entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#3  0x0000146751ce557b in __GI___waitpid (pid=<optimized out>, stat_loc=stat_loc
entry=0x7ffd16e54618, options=options
entry=0) at waitpid.c:38
#4  0x0000146751c3500d in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:172
#5  0x00001466fd1e1376 in TUnixSystem::Exec (this=0x56435d9de330, shellcmd=0x56436564dc20 "/home/furutaka/res/root-master-20260527-dbg/etc/gdb-backtrace.sh 3443799 1>&2") at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:2133
#6  0x00001466fd1e1c40 in TUnixSystem::StackTrace (this=0x56435d9de330) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:2424
#7  0x00001466fd8fd0ad in (anonymous namespace)::do_trace (sig=1) at /home/furutaka/work/root/root.git/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:274
#8  0x00001466fd8fd128 in (anonymous namespace)::TExceptionHandlerImp::HandleException (this=0x564360e4ede0, sig=1) at /home/furutaka/work/root/root.git/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:287
#9  0x00001466fd1e5805 in TUnixSystem::DispatchSignals (this=0x56435d9de330, sig=kSigSegmentationViolation) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:3646
#10 0x00001466fd1dd448 in SigHandler (sig=kSigSegmentationViolation) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:410
#11 0x00001466fd1e5708 in sighandler (sig=11) at /home/furutaka/work/root/root.git/core/unix/src/TUnixSystem.cxx:3622
#12 <signal handler called>
#13 0x00001466fd105219 in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:689
#14 0x00001466fc3e306c in ?? ()
#15 0x0000000000000000 in ?? ()
===========================================================


The lines below might hint at the cause of the crash. If you see question
marks as part of the stack trace, try to recompile with debugging information
enabled and export CLING_DEBUG=1 environment variable before running.
You may get help by asking at the ROOT forum https://root.cern/forum
preferably using the command (.forum bug) in the ROOT prompt.
Only if you are really convinced it is a bug in ROOT then please submit a
report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
the ROOT prompt. Please post the ENTIRE stack trace
from above as an attachment in addition to anything else
that might help us fixing this issue.
===========================================================
#13 0x00001466fd105219 in TCollection::Write (this=0x564365504340, name=0x0, option=0, bufsize=0) at /home/furutaka/work/root/root.git/core/cont/src/TCollection.cxx:689
#14 0x00001466fc3e306c in ?? ()
#15 0x0000000000000000 in ?? ()
===========================================================


Traceback (most recent call last):
  File "/home/furutaka/res/PHITS/mc-tools/mc-tools.git/bin/angel2root", line 632, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/furutaka/res/PHITS/mc-tools/mc-tools.git/bin/angel2root", line 627, in main
    angel =  Angel(fname_in, fname_out,avBitSet=args.average)
  File "/home/furutaka/res/PHITS/mc-tools/mc-tools.git/bin/angel2root", line 254, in __init__
    self.histos.Write()
    ~~~~~~~~~~~~~~~~~^^
cppyy.ll.SegmentationViolation: none of the 2 overloaded methods succeeded. Full details:
  int TCollection::Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) =>
    SegmentationViolation: segfault in C++; program state was reset
  int TCollection::Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) =>
    SegmentationViolation: segfault in C++; program state was reset
```