### PR TITLE
Proper(?) modification to avoid cppyy.ll.SegmentationViolation in angel2root.py

### DIFF
--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -15,7 +15,7 @@ import ROOT
 # The line below is needed to prevent command-line arguments from
 # stolen by PyROOT and handed to TApplication
 ROOT.PyConfig.IgnoreCommandLineOptions = True
-from ROOT import ROOT, TH1F, TH2F, TFile, TObjArray, TGraphErrors
+from ROOT import TH1F, TH2F, TFile, TObjArray, TGraphErrors
 
 """
 def isData(line):
@@ -277,7 +277,8 @@ class Angel:
                         self.Read1DHist(igline, npage)
                         continue
                     elif re.search("h:              x", line):
-                        self.Read1DGraphErrors(igline)
+                        if DEBUG: print("calling Read1DGraphErrors()")
+                        self.Read1DGraphErrors(igline, npage)
                         continue
                     elif re.search("^h[2dc]:", line):
                         if DEBUG:
@@ -491,11 +492,12 @@ class Angel:
             self.histos.Add(h)
         del self.subtitles[:]
 
-    def Read1DGraphErrors(self, iline):
+    def Read1DGraphErrors(self, iline, pageNum):
         """
         Read 1D graph section
         """
         ngraphs = self.GetNhist(self.lines[iline]) # graph and hist format is the same
+        if DEBUG: print("ngraphs: ", ngraphs)
         xarray = []
         data = {}
         errors = {}
@@ -509,6 +511,7 @@ class Angel:
             if line == '': break
             elif re.search("^#", line): continue
             words = line.split()
+            if DEBUG > 2: print("Read1DGraphErrors(): words = ",words)
             xarray.append(float(words[0]))
             for igraph in range(ngraphs):
                 data[igraph].append(  float(words[(igraph+1)*2-1  ]))
@@ -516,14 +519,48 @@ class Angel:
 
         npoints = len(xarray)
 
+        if DEBUG:
+            print("Read1DGraphErrors(): len(xarray) = ", len(xarray))
+            print("Read1DGraphErrors(): ngraphs = ", ngraphs)
+            print("Read1DGraphErrors(): len(data) = ", len(data))
+            print("Read1DGraphErrors(): len(errors) = ", len(errors))
+            for idx in range(ngraphs):
+                print("Read1DGraphErrors(): len(data[{}]) = {}".format(idx, len(data[idx])))
+                print("Read1DGraphErrors(): len(errors[{}]) = {}".format(idx, len(errors[idx])))
+            print("Read1DGraphErrors(): self.numPlotPages = ", self.numPlotPages)
+            if DEBUG > 1:
+                print("Read1DGraphErrors(): xarray = ", xarray)
+                for idx in range(ngraphs):
+                    print("Read1DGraphErrors(): data[{}]= {}".format(idx, data[idx]))
+                    print("Read1DGraphErrors(): errors[{}] = {}".format(idx, errors[idx]))
+
         for igraph in range(ngraphs):
-            if self.subtitles[igraph]: subtitle = ' - ' + self.subtitles[igraph]
+            if self.subtitles[igraph]: subtitle = ' - ' + self.subtitles[igraph+1]
             else: subtitle = ''
+            if DEBUG: print("Read1DGraphErrors(): subtitle = '{}'".format(subtitle))
             self.FixTitles()
             g = TGraphErrors(npoints)
+            ### Releasing the ownership
+            ROOT.SetOwnership(g, False) # old style.
+            # cppyy-based newer PyROOT.
+            # g.SetOwnership(False)
+            # -> AttributeError: 'TGraphErrors' object has no attribute 'SetOwnership'
             # self.ihist+1 - start from ONE as in Angel - easy to compare
-            g.SetNameTitle("g%d" % (self.ihist+1), "%s%s;%s;%s" % (self.title, subtitle, self.xtitle, self.ytitle))
+            if self.numPlotPages == 1:
+                if ngraphs == 1:
+                    gname = self.file
+                else:
+                    gname = "%s_%s" % (self.file, self.subtitles[igraph+1])
+            else:
+                if ngraphs == 1:
+                    gname = "%s_%d" % (self.file, pageNum)
+                else:
+                    gname = "%s_%d_%s" % (self.file, pageNum, self.subtitles[igraph+1])
+            if DEBUG: print("Read1DGraphErrors(): gname = ", gname)
+            g.SetNameTitle(gname, "%s%s;%s;%s" % (self.title, subtitle, self.xtitle, self.ytitle))
             self.ihist += 1
+            if DEBUG: print("Read1DGraphErrors(): name = '{}', title = '{}{};{};{}'".format(
+                gname, self.title, subtitle, self.xtitle, self.ytitle))
             for i in range(npoints):
                 x = xarray[i]
                 y = data[igraph][i]

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -64,6 +64,33 @@ def is_float(s):
         return False
 
 
+def splitHline(inLine):
+    """split an "h:" line into words w/ "(...)" taking into account
+    """
+    line = inLine.strip() # remove leading/trailing whitespaces
+    if DEBUG: print("splitHline: stripped line = '{}'".format(line),len(line))
+    staPos = [0] # start position of a word (the first should be 0)
+    endPos = []
+    inWord  = True  # True if in a word
+    inParen = False # True if between '(' and ')'
+    for idx in range(1,len(line)):
+        if line[idx] == '(': inParen = True
+        elif line[idx] == ')': inParen = False
+        elif line[idx] == ' ' and line[idx-1] != ' ' and not inParen:
+            endPos.append(idx)
+        elif line[idx] != ' ' and line[idx-1] == ' ' and not inParen:
+            staPos.append(idx)
+    endPos.append(len(line))
+    if DEBUG > 1:
+        print("splitHline: staPos: ", staPos,len(staPos))
+        print("splitHline: endPos: ", endPos,len(endPos))
+    words = []
+    for idx in range(len(staPos)):
+        words.append(line[staPos[idx]:endPos[idx]])
+    if DEBUG > 1: print("splitHline: words = :", words)
+    return words
+
+
 class Angel:
     fname = None
     title  = None
@@ -374,7 +401,7 @@ class Angel:
             line1 = line
             line = line.replace(' )', ')')
 
-        words = line.split()
+        words = splitHline(line)
         if DEBUG:
             print("GetNhist(): line = \'{}\'".format(line))
             if DEBUG > 1: print("GetNhist(): words = ", words)

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -212,7 +212,7 @@ class Angel:
                     self.axis.append(a)
                 if DEBUG: print("axis: ", self.axis)
                 iline += 1
-            elif re.search("^n[eartxyz] = ", line.strip()): # !!! make sence if we specify number of bins but not the bin width
+            elif re.search("^n[eartxyzl] = ", line.strip()): # !!! make sence if we specify number of bins but not the bin width
                 words = line.split()
                 self.dict_nbins[words[0]] = int(words[2])
                 self.last_nbins_read = words[0]

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -70,7 +70,7 @@ class Angel:
     part = [] # list of particles
     lines = []
     return_value = 0
-    numPlots = 0 # number of plots <- later deduced from len(pageLST)
+    numPlotPages = 0 # number of plot pages <- later deduced from len(pageLST)
 
 # this group of variables is used to convert a set of 1D histograms to 2D (if necessary):
     dict_nbins = {} # dictionary of number of bins - to guess if 2D histo is needed
@@ -125,8 +125,8 @@ class Angel:
         pageLST.append( tuple( self.lines[pageSepLineLST[-1]+1:] ) )
 
         #   the number of plot pages
-        self.numPlots = len(pageLST) - 1 # one header page
-        if DEBUG: print("numPlots: ", self.numPlots)
+        self.numPlotPages = len(pageLST) - 1 # one header page
+        if DEBUG: print("numPlotPages: ", self.numPlotPages)
 
         ##################################################
         # scan the first page and extract header information
@@ -390,7 +390,7 @@ class Angel:
             else: subtitle = ''
             self.FixTitles()
             # self.ihist+1 - start from ONE as in Angel - easy to compare
-            hname=self.file if self.numPlots == 1 else "%s%d" % (self.file, self.ihist+1)
+            hname=self.file if self.numPlotPages == 1 else "%s%d" % (self.file, self.ihist+1)
             h = TH1F(hname, "%s%s;%s;%s" % (self.title, subtitle, self.xtitle, self.ytitle), nbins, array('f', xarray))
             if self.avBitSet:
                 h.SetBit(TH1F.kIsAverage)

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -77,9 +77,7 @@ class Angel:
     last_nbins_read = None # last name of binning read (ne, nt, na, ...)
     dict_edges_array = {} # dictionary of arrays with bin edges
 
-    histos = TObjArray()
     ihist = 0 # histogram number - must start from ZERO
-    fname_out = None
     def __init__(self, fname_in, fname_out, **kwargs):
 #        global DEBUG
         #: a python list which contains the numbers of lines which separate
@@ -95,7 +93,9 @@ class Angel:
         self.lines = tuple(file.readlines())
         file.close()
 
-        self.fname_out = fname_out
+        # create the output anyway; remove if nothing to save
+        fout = TFile(fname_out, "recreate")
+        self.histos = TObjArray() # the owner is the output file
         self.avBitSet = kwargs["avBitSet"]
 
         ipage = -1
@@ -225,20 +225,17 @@ class Angel:
                 if re.search("^h", line):
                     if re.search("^h: [nx]", line): # !!! We are looking for 'h: n' instead of 'h' due to rz-plots.
                         if DEBUG: print("one dimentional graph section")
-                        tmp_h = self.Read1DHist(igline)
-                        self.histos.Add(tmp_h)
+                        self.Read1DHist(igline)
                         continue
                     elif re.search("h:              x", line):
-                        tmp_g = self.Read1DGraphErrors(igline)
-                        self.histos.Add(tmp_g)
+                        self.Read1DGraphErrors(igline)
                         continue
                     elif re.search("^h[2dc]:", line):
                         if DEBUG:
                             if re.search("^h2", line): print("h2: two dimentional contour plot section")
                             if re.search("^hd", line): print("hd: two dimentional cluster plot section")
                             if re.search("^hc", line): print("hc: two dimentional colour cluster plot section")
-                        tmp_h = self.Read2DHist(igline)
-                        self.histos.Add(tmp_h)
+                        self.Read2DHist(igline)
                         continue
                     elif 'reg' in self.axis: # line starts with 'h' and axis is 'reg' => 1D histo in region mesh. For instance, this is whe case with [t-deposit] tally and mesh = reg.
                         self.Read1DHist(igline)
@@ -249,18 +246,18 @@ class Angel:
             if DEBUG: print("1D")
         else:
             if DEBUG: print("2D")
-#            tmp_h2 = self.Make2Dfrom1D()
-#            self.histos.Add(tmp_h2)
+#            self.Make2Dfrom1D()
 
 
         if self.histos.GetEntries():
-            fout = TFile(self.fname_out, "recreate")
             self.histos.Write()
             fout.Close()
             self.return_value = 0
         else:
             print("Have not found any histograms/graphs in this file")
             self.return_value = 1
+            fout.Close()
+            os.remove(fname_out) # Nothing to write, remove the output file
 
     def is1D(self):
         """
@@ -409,7 +406,7 @@ class Angel:
                     h.GetXaxis().SetBinLabel(i+1, bin_labels[i])
                 h.GetXaxis().SetTitle("Region number")
 
-            return h
+            self.histos.Add(h)
         del self.subtitles[:]
 
     def Read1DGraphErrors(self, iline):
@@ -452,7 +449,7 @@ class Angel:
                 g.SetPoint(i, x, y)
                 g.SetPointError(i, 0, ey*y)
 
-            return g
+            self.histos.Add(g)
         del self.subtitles[:]
 
 
@@ -604,7 +601,7 @@ class Angel:
                 h2.SetBinError(binx+1, biny+1, h1.GetBinError(binx+1))
 
 
-        return h2
+        self.histos.Add(h2)
 
 
 

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -237,7 +237,9 @@ class Angel:
         # book and fill histograms
         ##################################################
         for npage in range(1, len(pageLST)):
+            if DEBUG: print("========== Page {} ==========".format(npage))
             # first scan: extract header info in advance to the data extraction
+            if DEBUG: print("---------- 1st scan ----------")
             for iline, line in enumerate(pageLST[npage]):
                 line.strip()
                 if re.search("^x:", line):
@@ -262,6 +264,7 @@ class Angel:
             # second scan: extract data.
             #              scan only within the current page, pass the corresponding
             #              global line number for data decoding
+            if DEBUG: print("---------- 2nd scan ----------")
             for iline, line in enumerate(pageLST[npage]):
                 line.strip()
                 #: 'global' line number (not in the current page).
@@ -271,7 +274,7 @@ class Angel:
                 if re.search("^h", line):
                     if re.search("^h: [nx]", line): # !!! We are looking for 'h: n' instead of 'h' due to rz-plots.
                         if DEBUG: print("one dimentional graph section")
-                        self.Read1DHist(igline)
+                        self.Read1DHist(igline, npage)
                         continue
                     elif re.search("h:              x", line):
                         self.Read1DGraphErrors(igline)
@@ -284,7 +287,8 @@ class Angel:
                         self.Read2DHist(igline)
                         continue
                     elif 'reg' in self.axis: # line starts with 'h' and axis is 'reg' => 1D histo in region mesh. For instance, this is whe case with [t-deposit] tally and mesh = reg.
-                        self.Read1DHist(igline)
+                        if DEBUG: print("calling Read1DHist() (region mesh)")
+                        self.Read1DHist(igline, npage)
                         continue
 
 #        print(self.dict_edges_array)
@@ -295,6 +299,7 @@ class Angel:
 #            self.Make2Dfrom1D()
 
 
+        if DEBUG: print("self.histos.GetEntries(): ", self.histos.GetEntries())
         if self.histos.GetEntries():
             self.histos.Write()
             fout.Close()
@@ -342,7 +347,7 @@ class Angel:
         for line in self.lines[iline+1:]:
             words =  line.split()
             if line[0] == '#': # if the distribution type is 1 or 2 then '#' is used
-                if DEBUG: print(words[1:])
+                if DEBUG > 1: print(words[1:])
                 for w in words[1:]:
                     edges.append(w)
             elif is_float(words[0]):
@@ -362,12 +367,16 @@ class Angel:
         """
 # Let's remove all spaces between ')'. For some reason line.replace('\s*)', ')') does not work
 # so we do it in this weird way:
+        if DEBUG: print("GetNhist(): line = \'{}\'".format(line))
         line1 = None
         while line1 != line:
             line1 = line
             line = line.replace(' )', ')')
 
         words = line.split()
+        if DEBUG:
+            print("GetNhist(): line = \'{}\'".format(line))
+            if DEBUG > 1: print("GetNhist(): words = ", words)
         nhists = 0
         for w in words:
             if re.search("^y", w):
@@ -381,7 +390,7 @@ class Angel:
         if DEBUG: print("Section Header: 1D histo", nhists, self.subtitles)
         return nhists
 
-    def Read1DHist(self, iline):
+    def Read1DHist(self, iline, pageNum):
         """
         Read 1D histogram section
         """
@@ -406,13 +415,15 @@ class Angel:
             if line == '': break
             elif re.search("^#", line): continue
             words = line.split()
-#            if DEBUG: print(words)
+            if DEBUG > 1: print("Read1DHist(): words = ",words)
             if isCharge:
+                if DEBUG: print("Read1DHist(): isCharge")
                 xarray.append(float(words[0])-0.5)
                 xmax = float(words[0])+0.5
                 data[0].append(float(words[1]))
                 errors[0].append(float(words[2]))
             elif 'reg' in self.axis:
+                if DEBUG: print("Read1DHist(): reg")
                 xarray.append(   float(words[0])-0.5)
                 xmax =           float(words[0])+0.5
                 bin_labels.append(words[1]) # region number
@@ -420,6 +431,7 @@ class Angel:
                     data[ihist].append(  float(words[(ihist+1)*2+1])    )
                     errors[ihist].append(float(words[(ihist+1)*2+2])    )
             else:
+                if DEBUG > 1: print("Read1DHist(): else")
                 xarray.append(float(words[0]))
                 xmax =        float(words[1])
                 for ihist in range(nhist):
@@ -429,14 +441,38 @@ class Angel:
         nbins = len(xarray)
         xarray.append(xmax)
 
-#        if DEBUG: print("data: ", data)
+        if DEBUG:
+            print("Read1DHist(): len(xarray) = ", len(xarray))
+            print("Read1DHist(): nhist = ", nhist)
+            print("Read1DHist(): len(data) = ", len(data))
+            print("Read1DHist(): len(errors) = ", len(errors))
+            for idx in range(nhist):
+                print("Read1DHist(): len(data[{}]) = {}".format(idx, len(data[idx])))
+                print("Read1DHist(): len(errors[{}]) = {}".format(idx, len(errors[idx])))
+            print("Read1DHist(): self.numPlotPages = ", self.numPlotPages)
+            if DEBUG > 1:
+                print("Read1DHist(): xarray= ", xarray)
+                for idx in range(nhist):
+                    print("Read1DHist(): data[{}]= {}".format(idx, data[idx]))
+                    print("Read1DHist(): errors[{}] = {}".format(idx, errors[idx]))
 
         for ihist in range(nhist):
-            if self.subtitles[ihist]: subtitle = ' - ' + self.subtitles[ihist]
+            if self.subtitles[ihist]: subtitle = ' - ' + self.subtitles[ihist+1]
             else: subtitle = ''
+            if DEBUG: print("Read1DHist(): subtitle = '{}'".format(subtitle))
             self.FixTitles()
             # self.ihist+1 - start from ONE as in Angel - easy to compare
-            hname=self.file if self.numPlotPages == 1 else "%s%d" % (self.file, self.ihist+1)
+            if self.numPlotPages == 1:
+                if nhist == 1:
+                    hname = "%s" % (self.file)
+                else:
+                    hname = "%s_%s" % (self.file, self.subtitles[ihist+1])
+            else:
+                if nhist == 1:
+                    hname = "%s_%d" % (self.file, pageNum)
+                else:
+                    hname = "%s_%d_%s" % (self.file, pageNum, self.subtitles[ihist+1])
+            if DEBUG: print("Read1DHist(): hname = '{}'".format(hname))
             h = TH1F(hname, "%s%s;%s;%s" % (self.title, subtitle, self.xtitle, self.ytitle), nbins, array('f', xarray))
             if self.avBitSet:
                 h.SetBit(TH1F.kIsAverage)

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -190,7 +190,8 @@ class Angel:
                 words = line.split()
                 self.mesh = words[2]
                 if DEBUG: print("mesh: ", self.mesh)
-                if self.mesh == "reg": # process line(s) for region mesh
+                if self.mesh == "reg" or self.mesh == "tet":
+                    # process line(s) for region/tetra mesh
                     # The next line should be "reg = ".
                     # Extract the string between '=' and '#'.
                     regStr = re.split(r"[=#]", pageLST[0][iline+1].strip())[1]
@@ -306,6 +307,12 @@ class Angel:
                     elif re.search("h:              x", line):
                         if DEBUG: print("calling Read1DGraphErrors()")
                         self.Read1DGraphErrors(igline, npage)
+                        continue
+                    elif re.search("h:   x      n     n", line) and \
+                    re.search("#    num    tetra   volume",
+                              pageLST[npage][iline+1].strip()): # tetra mesh
+                        if DEBUG: print("calling Read1DGraphErrors() for tetra mesh")
+                        self.Read1DGraphErrors(igline, npage, tet=True)
                         continue
                     elif re.search("^h([2d]|c2?):", line):
                         if DEBUG:
@@ -519,7 +526,7 @@ class Angel:
             self.histos.Add(h)
         del self.subtitles[:]
 
-    def Read1DGraphErrors(self, iline, pageNum):
+    def Read1DGraphErrors(self, iline, pageNum, tet=False):
         """
         Read 1D graph section
         """
@@ -528,6 +535,7 @@ class Angel:
         xarray = []
         data = {}
         errors = {}
+        tetShift = 2 if tet else 0 # column shift for tetra mesh
 
         for igraph in range(ngraphs):
             data[igraph] = []
@@ -541,8 +549,8 @@ class Angel:
             if DEBUG > 2: print("Read1DGraphErrors(): words = ",words)
             xarray.append(float(words[0]))
             for igraph in range(ngraphs):
-                data[igraph].append(  float(words[(igraph+1)*2-1  ]))
-                errors[igraph].append(float(words[(igraph+1)*2    ]))
+                data[igraph].append(  float(words[(igraph+1)*2-1+tetShift]))
+                errors[igraph].append(float(words[(igraph+1)*2  +tetShift]))
 
         npoints = len(xarray)
 

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -307,13 +307,13 @@ class Angel:
                         if DEBUG: print("calling Read1DGraphErrors()")
                         self.Read1DGraphErrors(igline, npage)
                         continue
-                    elif re.search("^h[2dc]:", line):
+                    elif re.search("^h([2d]|c2?):", line):
                         if DEBUG:
                             if re.search("^h2", line): print("h2: two dimentional contour plot section")
                             if re.search("^hd", line): print("hd: two dimentional cluster plot section")
                             if re.search("^hc", line): print("hc: two dimentional colour cluster plot section")
                         self.Read2DHist(igline)
-                        continue
+                        break # no need to scan further, only to find color palette etc.
                     elif 'reg' in self.axis: # line starts with 'h' and axis is 'reg' => 1D histo in region mesh. For instance, this is whe case with [t-deposit] tally and mesh = reg.
                         if DEBUG: print("calling Read1DHist() (region mesh)")
                         self.Read1DHist(igline, npage)
@@ -614,8 +614,10 @@ class Angel:
         Read 2D histogram section
         """
 
+        if DEBUG: print("Read2DHist(): invoked with iline = ", iline)
         line = self.lines[iline].replace(" =", "=") # sometimes Angel writes 'y=' and sometimes 'y ='
         words = line.split()
+        if DEBUG: print("Read2DHist(): words = ", words)
         if len(words) != 15:
             print(words)
             print(len(words))
@@ -637,7 +639,7 @@ class Angel:
             else:
                 ymin,ymax = ymax+dy/2.0, ymin-dy/2.0
         ny = abs(int(round((ymax-ymin)/dy)))
-        if DEBUG: print("y:", dy, ymin, ymax, ny)
+        if DEBUG: print("Read2DHsit(): y: (ymin,ymax,dy,ny) = ({},{},{},{})".format(ymin,ymax,dy,ny))
 
         dx = float(words[13])
         xmin = float(words[9])
@@ -647,21 +649,22 @@ class Angel:
         else:
             xmin,xmax = xmax-dx/2.0, xmin+dx/2.0
         nx = int(round((xmax-xmin)/dx))
-        if DEBUG: print("x:", dx, xmin, xmax, nx)
+        if DEBUG: print("Read2DHist(): x: (xmin,xmax,dx,nx) = ({},{},{},{})".format(xmin,xmax,dx,nx))
 
         data = []
         for line in self.lines[iline+1:]:
             line = line.strip()
+            if DEBUG > 1: print("Read2DHist(): line = '{}'".format(line))
             if line == '': break
             elif re.search("^#", line): continue
             words = line.split()
-#            if DEBUG: print("words: ", words)
+            if DEBUG > 1: print("Read2DHist(): words = ", words)
             for w in words:
                 if w == 'z:':
-#                    if DEBUG: print("this is a color palette -> exit")
+                    if DEBUG: print("Read2DHist(): this is a color palette -> exit")
                     return # this was a color palette
                 data.append(float(w))
-#        if DEBUG: print(data)
+        if DEBUG > 1: print("Read2DHist(): data = ", data)
 
         # self.ihist+1 - start from ONE as in Angel - easy to compare
         h = TH2F("h%d" % (self.ihist+1), "%s - %s;%s;%s;%s" % (self.title, self.subtitles[self.ihist], self.xtitle, self.ytitle, self.ztitle), nx, xmin, xmax, ny, ymin, ymax)

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -136,6 +136,7 @@ class Angel:
         fout = TFile(fname_out, "recreate")
         self.histos = TObjArray() # the owner is the output file
         self.avBitSet = kwargs["avBitSet"]
+        self.sangel = False # existence of additional angel instruction w/ "sangel = "
 
         ipage = -1
 
@@ -256,6 +257,10 @@ class Angel:
                     print("self.mult_mat : ", self.mult_mat)
                     print("self.mult_mul:  ", self.mult_mul)
                 iline += 5
+            elif re.search("sangel =", line):
+                self.sangel = True
+                if DEBUG: print("sangel = True: '{}'".format(pageLST[0][iline].strip()))
+                iline += 1
             else:
                 iline += 1 # just advance one line
         if DEBUG: print("========== Finish processing the header page ==========")
@@ -268,6 +273,7 @@ class Angel:
             if DEBUG: print("========== Page {} ==========".format(npage))
             # first scan: extract header info in advance to the data extraction
             if DEBUG: print("---------- 1st scan ----------")
+            hLST = [] # list of 'H-tuples', (Line#OfH,"typeOfH"). ("typeOfH" is redundant)
             for iline, line in enumerate(pageLST[npage]):
                 line.strip()
                 if re.search("^x:", line):
@@ -288,12 +294,18 @@ class Angel:
                 elif re.search("'no. =", line): # subtitles of 2D histogram
                     self.subtitles.append(' '.join(line[line.find(',')+1:].split()).replace("\'", '').strip())
                     if DEBUG: print("subtitle:", self.subtitles)
+                elif re.search("^h", line):
+                    if DEBUG: print("h-line found: '{}'".format(line))
+                    hLST.append( (iline,line.split()[0]) ) # H-tuple
+            if DEBUG: print("hLST: ", hLST)
 
             # second scan: extract data.
             #              scan only within the current page, pass the corresponding
             #              global line number for data decoding
             if DEBUG: print("---------- 2nd scan ----------")
             for iline, line in enumerate(pageLST[npage]):
+                # skip to the last histogram in this page
+                if self.sangel and iline < hLST[-1][0]: continue
                 line.strip()
                 #: 'global' line number (not in the current page).
                 #: The counting of local line number (iline) start just after

--- a/mctools/phits/angel2root.py
+++ b/mctools/phits/angel2root.py
@@ -39,7 +39,19 @@ SUBT = re.compile(r"""
 #: a regular expression which describes the page-separating line.
 pageSepRE = re.compile(r"^[\s#]newpage:$")
 
-DEBUG = False
+#: a regular expression to search for continuation lines of "reg = "
+regMeshRE = re.compile(r"^ *([,0-9{}<\(\)\[\]\-\+]|all|u *=).*")
+
+#: a regular expression to separate the values in multiplier subsection
+#  ex.1      mat                   mset1
+#            all ( 1.79077E-13 2002 1 -4 )
+#         => ['( 1.79077E-13 2002 1 -4 )']
+#  ex.2      mat         mset1           mset2           mset3
+#            all ( 1.0000 -250 ) ( 1.0000 -200 ) ( 1.0000 -201 )
+#         => ['( 1.0000 -250 )','( 1.0000 -200 )','( 1.0000 -201 )]
+mulDataRE = re.compile(r"(\(.*?\))+") # match non-greedily
+
+DEBUG = 0 # accept integral value. (> 1 to print the data)
 
 def is_float(s):
     """
@@ -131,60 +143,94 @@ class Angel:
         ##################################################
         # scan the first page and extract header information
         ##################################################
-        for iline, line in enumerate(pageLST[0]):
-            line.strip()
+        if DEBUG > 1:
+            # print each tuple element
+            print("Header Page as a tuple of strings: \n", pageLST[0])
+            print("Strings(stripped):")
+            for elNo in range(len(pageLST[0])):
+                print("\t",elNo,pageLST[0][elNo].strip())
+        if DEBUG: print("========== Start processing the header page ==========")
+        iline = 0
+        while iline < len(pageLST[0]):
+            line = pageLST[0][iline].strip()
+            # print("{}: line = \'{}\'".format(iline,line))
             if re.search("title = ", line):
                 words = line.split()
                 self.title = ' '.join(words[2:])
                 if DEBUG: print("title: ", self.title)
-                continue
-            if re.search("mesh = ", line):
+                iline += 1
+            elif re.search("mesh = ", line):
                 words = line.split()
                 self.mesh = words[2]
                 if DEBUG: print("mesh: ", self.mesh)
-                continue
-            if re.search("axis = ", line):
+                if self.mesh == "reg": # process line(s) for region mesh
+                    # The next line should be "reg = ".
+                    # Extract the string between '=' and '#'.
+                    regStr = re.split(r"[=#]", pageLST[0][iline+1].strip())[1]
+                    if DEBUG: print("regStr(1st): ", regStr)
+                    # The region line(s) may continue...
+                    iline += 2 # start from the next of "reg = "
+                    while True:
+                        if regMeshRE.match(pageLST[0][iline]):
+                            regStr += pageLST[0][iline].strip()
+                            iline += 1
+                            if DEBUG: print("\tiline => ",iline)
+                        else:
+                            break
+                    if DEBUG: print("regStr(fin): ", regStr)
+                else: iline += 1
+            elif re.search("axis = ", line):
                 for a in line.split()[2:]:
                     if a == '#': break
                     self.axis.append(a)
                 if DEBUG: print("axis: ", self.axis)
-                continue
-            if re.search("reg = ", line):
-                for r in line.split()[2:]:
-                    if r == '#': break
-                    self.reg.append(r)
-                if DEBUG: print("reg: ", self.reg)
-                continue
-            if re.search("^n[eartxyz] = ", line.strip()): # !!! make sence if we specify number of bins but not the bin width
+                iline += 1
+            elif re.search("^n[eartxyz] = ", line.strip()): # !!! make sence if we specify number of bins but not the bin width
                 words = line.split()
                 self.dict_nbins[words[0]] = int(words[2])
                 self.last_nbins_read = words[0]
                 if DEBUG: print("dict_nbins:", self.dict_nbins)
-                continue
-            if re.search("#    data = ", line):
+                iline += 1
+            elif re.search("#    data = ", line):
                 self.dict_edges_array[self.last_nbins_read] = self.GetBinEdges(iline)
-                continue
-            if re.search("part = ", line):
+                iline += 1
+            elif re.search("part = ", line):
                 words = line.split()
-# this loop is needed in case we define particles in separate lines as shown on page 121 of the Manual. Otherwise we could have used 'self.part = words[2:]'
-                for w in words[2:]: self.part.append(w)
+                # The "part = " line immediately below the "multiplier = all"
+                # solely belongs and applys to the multiplier subsection.
+                self.part = words[2:]
                 if DEBUG: print("particles:", self.part)
-                continue
-            if re.search("output = ", line):
+                iline += 1
+            elif re.search("output = ", line):
                 words = line.split()
                 self.output = words[2]
                 self.output_title = ' '.join(words[4:])
                 if self.unit_title != None: self.ztitle = self.output_title + " " + self.unit_title
-                continue
-            if re.search("unit = ", line):
+                iline += 1
+            elif re.search("unit = ", line):
                 words = line.split()
                 self.unit = words[2]
                 self.unit_title = ' '.join(words[6:])
                 if self.output_title != None: self.ztitle = self.output_title + " " + self.unit_title
-                continue
-            if re.search("file = ", line):
+                iline += 1
+            elif re.search("file = ", line):
                 words = line.split()
                 self.file, ext = os.path.splitext(words[2])
+                iline += 1
+            elif re.search("multiplier = ", line):
+                self.mult_part = pageLST[0][iline+1].strip().split()[2]
+                self.mult_emax = pageLST[0][iline+3].strip().split()[2]
+                self.mult_mat  = pageLST[0][iline+4].strip().split()[1:]
+                self.mult_mul = mulDataRE.findall(pageLST[0][iline+5].strip()) # non-greedy
+                if DEBUG:
+                    print("self.mult_part: ", self.mult_part)
+                    print("self.mult_emax: ", self.mult_emax)
+                    print("self.mult_mat : ", self.mult_mat)
+                    print("self.mult_mul:  ", self.mult_mul)
+                iline += 5
+            else:
+                iline += 1 # just advance one line
+        if DEBUG: print("========== Finish processing the header page ==========")
 
         ##################################################
         # scan the remaining data pages one by one


### PR DESCRIPTION
Hi.

I must apologize that the previous PR I made was wrong; the script still SEGVs in case there are multiple plots in an angel file. We must use the way I described in [this comment](https://github.com/kbat/mc-tools/pull/14#issuecomment-4627846588). 
Further, the modification which can avoid SEGV for `TH1` is not enough for `TGraphErros`; we have to explicitly release the ownership by using `ROOT.SetOwnership()`.
In addition to the above, I changed the loop to scan the 1st page from `for` to `while, to process some lines as a group.

The present modifications also include
- the addition of a lot of debug-print lines,
- the change of naming schemes for TH1 and TGraphErrors to differentiate multiple plots,
- the change of variable name from `numPlots` to `numPlotPages`,
- introduction of multiple DEBUG levels (integer).

I have checked the function of the script by converting many angel files coming with PHITS v.3.36.
Many of them could be successfully converted, some failed (later I'll investigate the reasons).
I'd like to ask you to carefully review the modification: I have one criminal record!

TODOs:
- Refine the criteria to distinguish the type of a plot; phits developers do not tightly fix the format of the histogram header line, e.g. the number of whitespaces between `h:` and `n`/`x`.
-  Modify to properly process angel files which contains geometry drawing statements starting with `# gshow`.